### PR TITLE
Allow skipping clash binary setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clashrup"
 description = "Simple CLI to manage your systemd clash.service and config subscriptions on Linux."
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,7 +129,6 @@ pub fn parse_config(path: &str, prefix: &str) -> Result<Config, ConfigError> {
     match Config::setup_from(path) {
         Ok(config) => {
             let required_urls = [
-                ("remote_clash_binary_url", &config.remote_clash_binary_url),
                 ("remote_config_url", &config.remote_config_url),
                 ("remote_mmdb_url", &config.remote_mmdb_url),
             ];


### PR DESCRIPTION
If clash binary already exists at `clash_binary_path` then skip clash executable setup. This also allows setting `remote_clash_binary_url` as empty. Close #5