### PR TITLE
feat: additional proxy export cmds (based on $SHELL)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clashrup"
 description = "Simple CLI to manage your systemd clash.service and config subscriptions on Linux."
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
### Description

- Add support for `fish` shell proxy export and unset commands
- Automatically determine shell based on `$SHELL`

### Linked Issues

fixes #10
