### PR TITLE
feat: manage external ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "shellexpand",
+ "tar",
  "tempfile",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ truncatable = "0.1"
 anyhow = "1.0"
 base64 = "0.22"
 tempfile = "3.18"
+tar = "0.4"
 self_update = { version = "0.42", default-features = false, features = [
     "archive-tar",
     "compression-flate2",

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ To update `mihomo` binary (core) and/or geodata:
 ```bash
 mihoro update --core     # updates core
 mihoro update --geodata  # updates geodata
-mihoro update --all      # updates config -> core -> geodata -> restarts mihomo
+mihoro update --ui       # updates external UI assets
+mihoro update --all      # updates config -> geodata -> core -> ui -> restarts mihomo
 ```
 
 To enable auto-update via cron job:
@@ -228,7 +229,7 @@ On controlling `mihomo` itself, we recommend using a web-based dashboard. Some o
 
 Web-based dashboards require enabling `external_controller` under `[mihomo_config]`. Applying this config will expose `mihomo`'s control API under this address, which you can then configure your dashboard to use this as its backend.
 
-You can also put the static files of these dashboards under the `external_ui` directory if defined. In this case, `mihomo` will serve the dashboard locally under `{external_controller}/ui`. Please refer to the official documentation of mihomo for more information: [docs/external_controller](https://wiki.metacubex.one/config/general/#api), [docs/external_ui](https://wiki.metacubex.one/config/general/#_7).
+`mihoro` manages dashboard source via top-level `ui` config, which defaults to `metacubexd` and also supports `zashboard`, `yacd-meta`, or `custom:download_url`. The downloaded static files are placed into `mihomo_config.external_ui`. In this case, `mihomo` will serve the dashboard locally under `{external_controller}/ui`. Please refer to the official documentation of mihomo for more information: [docs/external_controller](https://wiki.metacubex.one/config/general/#api), [docs/external_ui](https://wiki.metacubex.one/config/general/#_7).
 
 ## License
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -34,6 +34,10 @@ pub enum Commands {
         #[arg(long)]
         config: bool,
 
+        /// Update external UI assets
+        #[arg(long)]
+        ui: bool,
+
         /// Update mihomo core binary
         #[arg(long)]
         core: bool,
@@ -43,7 +47,7 @@ pub enum Commands {
         geodata: bool,
 
         /// Update everything: config, geodata, and mihomo core binary
-        #[arg(long, conflicts_with_all = ["config", "core", "geodata"])]
+        #[arg(long, conflicts_with_all = ["config", "ui", "core", "geodata"])]
         all: bool,
 
         /// Override architecture detection (used with --core or --all)
@@ -138,4 +142,43 @@ pub enum CronCommands {
     Disable,
     /// Show auto-update cron job status
     Status,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_update_ui_flag() {
+        let args = Args::parse_from(["mihoro", "update", "--ui"]);
+        match args.command {
+            Some(Commands::Update {
+                ui,
+                config,
+                core,
+                geodata,
+                all,
+                ..
+            }) => {
+                assert!(ui);
+                assert!(!config);
+                assert!(!core);
+                assert!(!geodata);
+                assert!(!all);
+            }
+            _ => panic!("expected update command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_update_all_flag() {
+        let args = Args::parse_from(["mihoro", "update", "--all"]);
+        match args.command {
+            Some(Commands::Update { all, ui, .. }) => {
+                assert!(all);
+                assert!(!ui);
+            }
+            _ => panic!("expected update command"),
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::ui::{default_ui, Ui};
 use crate::utils::create_parent_dir;
 
 use std::{collections::HashMap, fs, path::Path};
@@ -21,6 +22,8 @@ pub enum MihomoChannel {
 #[serde(default)]
 pub struct Config {
     pub remote_config_url: String,
+    #[serde(default = "default_ui", skip_serializing_if = "Option::is_none")]
+    pub ui: Option<Ui>,
     pub mihomo_channel: MihomoChannel,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_mihomo_binary_url: Option<String>,
@@ -38,6 +41,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
+            ui: default_ui(),
             remote_mihomo_binary_url: None,
             mihomo_channel: MihomoChannel::default(),
             mihomo_arch: None,
@@ -67,7 +71,7 @@ pub struct MihomoConfig {
     log_level: MihomoLogLevel,
     ipv6: Option<bool>,
     external_controller: Option<String>,
-    external_ui: Option<String>,
+    pub external_ui: Option<String>,
     secret: Option<String>,
     pub geodata_mode: Option<bool>,
     pub geo_auto_update: Option<bool>,
@@ -319,6 +323,7 @@ mod tests {
             read_config.remote_config_url,
             "http://example.com/config.yaml"
         );
+        assert_eq!(read_config.ui, Some(Ui::Metacubexd));
 
         Ok(())
     }
@@ -377,6 +382,25 @@ mod tests {
         assert!(updated_content.contains("port: 7891"));
         assert!(updated_content.contains("socks-port: 7892"));
         assert!(updated_content.contains("proxies:"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_config_uses_default_ui() -> Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("test.toml");
+
+        let toml_content = r#"
+            remote_config_url = "http://example.com/config.yaml"
+            mihomo_binary_path = "~/.local/bin/mihomo"
+            mihomo_config_root = "~/.config/mihomo"
+            user_systemd_root = "~/.config/systemd/user"
+        "#;
+        fs::write(&config_path, toml_content)?;
+
+        let config = parse_config(config_path.to_str().unwrap())?;
+        assert_eq!(config.ui, Some(Ui::Metacubexd));
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod mihoro;
 mod proxy;
 mod resolve_mihomo_bin;
 mod systemctl;
+mod ui;
 #[cfg(feature = "self_update")]
 mod upgrade;
 mod utils;
@@ -46,6 +47,7 @@ async fn cli() -> Result<()> {
             geodata,
             all,
             arch,
+            ui,
         }) => {
             if *all {
                 // Update config (without restarting yet)
@@ -72,6 +74,10 @@ async fn cli() -> Result<()> {
                 if let Err(e) = mihoro.update_core(&client, arch.as_deref(), false).await {
                     eprintln!("{} Failed to update core: {}", mihoro.prefix.yellow(), e);
                 }
+                println!("{} Updating UI...", mihoro.prefix.magenta().bold().italic());
+                if let Err(e) = mihoro.update_ui(&client).await {
+                    eprintln!("{} Failed to update UI: {}", mihoro.prefix.yellow(), e);
+                }
                 // Restart service once at the end
                 println!(
                     "{} Restarting mihomo.service...",
@@ -80,9 +86,11 @@ async fn cli() -> Result<()> {
                 Systemctl::new().restart("mihomo.service").execute()?;
             } else if *core {
                 mihoro.update_core(&client, arch.as_deref(), true).await?;
+            } else if *ui {
+                mihoro.update_ui(&client).await?;
             } else if *geodata {
                 mihoro.update_geodata(&client).await?;
-            } else if *config || (!*core && !*geodata) {
+            } else if *config || (!*core && !*geodata && !*ui) {
                 // Explicit --config or default (no flags)
                 mihoro.update_config(&client, true).await?;
             }

--- a/src/mihoro.rs
+++ b/src/mihoro.rs
@@ -4,13 +4,14 @@ use crate::cron;
 use crate::proxy::{proxy_export_cmd, proxy_unset_cmd};
 use crate::resolve_mihomo_bin;
 use crate::systemctl::Systemctl;
+use crate::ui::{install_ui, resolve_external_ui_path};
 use crate::utils::{
     create_parent_dir, delete_file, download_file, extract_gzip, try_decode_base64_file_inplace,
 };
 
 use std::fs;
 use std::os::unix::prelude::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use colored::Colorize;
@@ -134,6 +135,9 @@ impl Mihoro {
 
         // Download geodata
         self.update_geodata(&client).await?;
+
+        // Install external UI assets if configured
+        self.update_ui(&client).await?;
 
         // Create mihomo.service systemd file
         create_mihomo_service(
@@ -285,6 +289,34 @@ impl Mihoro {
         Ok(())
     }
 
+    pub async fn update_ui(&self, client: &Client) -> Result<()> {
+        let Some(ui) = self.config.ui.as_ref() else {
+            println!("{} UI management disabled, skipping", self.prefix.yellow());
+            return Ok(());
+        };
+
+        let Some(target_dir) = self.external_ui_target_dir() else {
+            println!(
+                "{} `external_ui` undefined, skipping UI installation",
+                self.prefix.yellow()
+            );
+            return Ok(());
+        };
+
+        println!(
+            "{} Updating external UI assets...",
+            self.prefix.cyan().bold()
+        );
+        install_ui(
+            client,
+            ui,
+            &target_dir,
+            &self.config.mihoro_user_agent,
+            &self.prefix.green(),
+        )
+        .await
+    }
+
     pub async fn apply(&self) -> Result<()> {
         // Apply mihomo config override
         apply_mihomo_override(&self.mihomo_target_config_path, &self.config.mihomo_config).map(
@@ -388,6 +420,16 @@ impl Mihoro {
             }
             _ => Ok(()),
         }
+    }
+
+    fn external_ui_target_dir(&self) -> Option<PathBuf> {
+        self.config
+            .mihomo_config
+            .external_ui
+            .as_deref()
+            .map(|external_ui| {
+                resolve_external_ui_path(&self.mihomo_target_config_root, external_ui)
+            })
     }
 }
 
@@ -523,6 +565,31 @@ mod tests {
 
         let cmd = mihoro.proxy_commands(&Some(ProxyCommands::Export));
         assert!(cmd.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_external_ui_target_dir_resolves_relative_path() -> Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("test.toml");
+
+        let toml_content = r#"
+            remote_config_url = "http://example.com/config.yaml"
+            mihomo_binary_path = "/tmp/test/mihomo"
+            mihomo_config_root = "/tmp/test/mihomo"
+            user_systemd_root = "/tmp/test/systemd"
+
+            [mihomo_config]
+            external_ui = "ui"
+        "#;
+        fs::write(&config_path, toml_content)?;
+
+        let mihoro = Mihoro::new(&config_path.to_str().unwrap().to_string())?;
+        assert_eq!(
+            mihoro.external_ui_target_dir(),
+            Some(PathBuf::from("/tmp/test/mihomo/ui"))
+        );
 
         Ok(())
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,288 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use flate2::read::GzDecoder;
+use reqwest::Client;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tar::Archive;
+use tempfile::{tempdir_in, NamedTempFile};
+
+use crate::utils::{create_parent_dir, download_file};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Ui {
+    #[default]
+    Metacubexd,
+    Zashboard,
+    YacdMeta,
+    Custom(String),
+}
+
+impl Ui {
+    pub fn parse(raw: &str) -> Result<Self> {
+        let value = raw.trim();
+        if value.is_empty() {
+            bail!("ui must not be empty");
+        }
+
+        match value {
+            "metacubexd" => Ok(Self::Metacubexd),
+            "zashboard" => Ok(Self::Zashboard),
+            "yacd-meta" => Ok(Self::YacdMeta),
+            _ => {
+                let Some(url) = value.strip_prefix("custom:") else {
+                    bail!("unsupported ui `{value}`");
+                };
+                if url.is_empty() {
+                    bail!("custom ui download url must not be empty");
+                }
+                Ok(Self::Custom(url.to_string()))
+            }
+        }
+    }
+
+    pub fn as_config_value(&self) -> &str {
+        match self {
+            Self::Metacubexd => "metacubexd",
+            Self::Zashboard => "zashboard",
+            Self::YacdMeta => "yacd-meta",
+            Self::Custom(url) => url.as_str(),
+        }
+    }
+
+    pub fn download_url(&self) -> &str {
+        match self {
+            Self::Metacubexd => {
+                "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.tar.gz"
+            }
+            Self::Zashboard => {
+                "https://github.com/Zephyruso/zashboard/archive/refs/heads/gh-pages.tar.gz"
+            }
+            Self::YacdMeta => {
+                "https://github.com/MetaCubeX/Yacd-meta/archive/refs/heads/gh-pages.tar.gz"
+            }
+            Self::Custom(url) => url.as_str(),
+        }
+    }
+}
+
+impl Serialize for Ui {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            Self::Custom(url) => format!("custom:{url}"),
+            _ => self.as_config_value().to_string(),
+        };
+        serializer.serialize_str(&value)
+    }
+}
+
+impl<'de> Deserialize<'de> for Ui {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ui::parse(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+pub fn default_ui() -> Option<Ui> {
+    Some(Ui::default())
+}
+
+pub fn resolve_external_ui_path(config_root: &str, external_ui: &str) -> PathBuf {
+    let path = Path::new(external_ui);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        Path::new(config_root).join(path)
+    }
+}
+
+pub async fn install_ui(
+    client: &Client,
+    ui: &Ui,
+    target_dir: &Path,
+    user_agent: &str,
+    prefix: &str,
+) -> Result<()> {
+    let archive_file = NamedTempFile::new()?;
+    download_file(client, ui.download_url(), archive_file.path(), user_agent).await?;
+
+    create_parent_dir(target_dir)?;
+    let target_parent = target_dir
+        .parent()
+        .with_context(|| format!("parent directory of `{}` invalid", target_dir.display()))?;
+    let extract_dir = tempdir_in(target_parent)?;
+    extract_tar_gz(archive_file.path(), extract_dir.path())?;
+
+    let extracted_root = find_archive_root(extract_dir.path())?;
+    replace_dir(&extracted_root, target_dir)?;
+
+    println!(
+        "{} Installed UI `{}` to {}",
+        prefix,
+        ui.as_config_value(),
+        target_dir.display()
+    );
+    Ok(())
+}
+
+fn extract_tar_gz(archive_path: &Path, extract_dir: &Path) -> Result<()> {
+    let archive = fs::File::open(archive_path)?;
+    let decoder = GzDecoder::new(archive);
+    let mut archive = Archive::new(decoder);
+    archive.unpack(extract_dir)?;
+    Ok(())
+}
+
+fn find_archive_root(extract_dir: &Path) -> Result<PathBuf> {
+    let mut entries = fs::read_dir(extract_dir)?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+
+    if entries.len() != 1 {
+        bail!(
+            "expected one root entry in extracted ui archive, found {}",
+            entries.len()
+        );
+    }
+
+    let root = entries.remove(0);
+    if !root.is_dir() {
+        bail!("expected extracted ui archive root to be a directory");
+    }
+    Ok(root)
+}
+
+fn replace_dir(source_dir: &Path, target_dir: &Path) -> Result<()> {
+    create_parent_dir(target_dir)?;
+
+    let parent = target_dir
+        .parent()
+        .with_context(|| format!("parent directory of `{}` invalid", target_dir.display()))?;
+
+    let staged_dir = parent.join(format!(
+        ".{}.tmp",
+        target_dir
+            .file_name()
+            .ok_or_else(|| anyhow!("invalid ui target directory"))?
+            .to_string_lossy()
+    ));
+    let backup_dir = parent.join(format!(
+        ".{}.bak",
+        target_dir
+            .file_name()
+            .ok_or_else(|| anyhow!("invalid ui target directory"))?
+            .to_string_lossy()
+    ));
+
+    if staged_dir.exists() {
+        fs::remove_dir_all(&staged_dir)?;
+    }
+    if backup_dir.exists() {
+        fs::remove_dir_all(&backup_dir)?;
+    }
+
+    fs::rename(source_dir, &staged_dir)?;
+
+    if target_dir.exists() {
+        fs::rename(target_dir, &backup_dir)?;
+    }
+
+    if let Err(err) = fs::rename(&staged_dir, target_dir) {
+        if backup_dir.exists() {
+            let _ = fs::rename(&backup_dir, target_dir);
+        }
+        return Err(err).with_context(|| {
+            format!(
+                "failed to move extracted ui into `{}`",
+                target_dir.display()
+            )
+        });
+    }
+
+    if backup_dir.exists() {
+        fs::remove_dir_all(backup_dir)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct UiConfig {
+        ui: Ui,
+    }
+
+    #[test]
+    fn test_builtin_ui_parse() -> Result<()> {
+        assert_eq!(Ui::parse("metacubexd")?, Ui::Metacubexd);
+        assert_eq!(Ui::parse("zashboard")?, Ui::Zashboard);
+        assert_eq!(Ui::parse("yacd-meta")?, Ui::YacdMeta);
+        Ok(())
+    }
+
+    #[test]
+    fn test_custom_ui_parse() -> Result<()> {
+        assert_eq!(
+            Ui::parse("custom:https://example.com/ui.tar.gz")?,
+            Ui::Custom("https://example.com/ui.tar.gz".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_ui_download_url() {
+        assert_eq!(
+            Ui::Metacubexd.download_url(),
+            "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.tar.gz"
+        );
+        assert_eq!(
+            Ui::Zashboard.download_url(),
+            "https://github.com/Zephyruso/zashboard/archive/refs/heads/gh-pages.tar.gz"
+        );
+        assert_eq!(
+            Ui::YacdMeta.download_url(),
+            "https://github.com/MetaCubeX/Yacd-meta/archive/refs/heads/gh-pages.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_resolve_external_ui_path() {
+        assert_eq!(
+            resolve_external_ui_path("/tmp/mihomo", "ui"),
+            PathBuf::from("/tmp/mihomo/ui")
+        );
+        assert_eq!(
+            resolve_external_ui_path("/tmp/mihomo", "/var/www/ui"),
+            PathBuf::from("/var/www/ui")
+        );
+    }
+
+    #[test]
+    fn test_ui_serde_roundtrip() -> Result<()> {
+        let encoded = r#"ui = "custom:https://example.com/ui.tar.gz""#;
+        let decoded: UiConfig = toml::from_str(encoded)?;
+        assert_eq!(
+            decoded,
+            UiConfig {
+                ui: Ui::Custom("https://example.com/ui.tar.gz".to_string())
+            }
+        );
+        assert_eq!(toml::to_string(&decoded)?.trim(), encoded);
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Description

Added a new `ui` config field to manage which external dashboard Mihoro should download and install. It defaults to `metacubexd`, also supports the built-in values `zashboard` and `yacd-meta`, and accepts custom sources in the form `custom:download_url`.

```toml
ui = "metacubexd"
# custom
ui = "custom:https://your/own/mirror/to/ui.tar.gz"
```

### Linked Issues

Implement #185 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
