### PR TITLE
Add mihoro init command with stage-based reporting and HTTP retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -384,6 +404,17 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -672,6 +703,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1108,6 +1140,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "dialoguer",
  "flate2",
  "futures-util",
  "indicatif",
@@ -1121,6 +1154,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-retry",
  "toml",
  "truncatable",
 ]
@@ -1421,7 +1455,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1436,13 +1470,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1494,6 +1528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,7 +1598,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1878,9 +1929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
@@ -2051,11 +2108,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2129,6 +2206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f644c762e9d396831ae2f8935c954b0d758c4532e924bead0f666d0c1c8640"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -2938,7 +3026,7 @@ checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihoro"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mihoro"
 description = "Mihomo CLI client on Linux."
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,13 @@ reqwest = { version = "0.12", features = ["stream"] }
 futures-util = "0.3"
 indicatif = "0.17"
 tokio = { version = "1.44", features = ["full"] }
+tokio-retry = "0.3"
 truncatable = "0.1"
 anyhow = "1.0"
 base64 = "0.22"
 tempfile = "3.18"
 tar = "0.4"
+dialoguer = { version = "0.11", default-features = false }
 self_update = { version = "0.42", default-features = false, features = [
     "archive-tar",
     "compression-flate2",

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -12,11 +12,15 @@ pub struct Args {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Setup mihoro by downloading mihomo binary and remote config
-    Setup {
-        /// Force download mihomo binary even if it already exists
+    /// Initialize mihoro: download binary, config, geodata, and set up the systemd service
+    Init {
+        /// Re-download all artifacts even if they already exist
         #[arg(long)]
-        overwrite: bool,
+        force: bool,
+
+        /// Non-interactive mode: fail if required config fields are missing instead of prompting
+        #[arg(short = 'y', long)]
+        yes: bool,
 
         /// Override architecture detection
         ///
@@ -25,6 +29,17 @@ pub enum Commands {
         /// arm64, armv5, armv6, armv7, loong64-abi1/abi2, mips-hardfloat,
         /// mips-softfloat, mips64, mips64le, mipsle-hardfloat, mipsle-softfloat,
         /// ppc64le, riscv64, s390x
+        #[arg(long)]
+        arch: Option<String>,
+    },
+    /// Deprecated: use `mihoro init` instead
+    #[command(hide = true)]
+    Setup {
+        /// Force download mihomo binary even if it already exists
+        #[arg(long)]
+        overwrite: bool,
+
+        /// Override architecture detection
         #[arg(long)]
         arch: Option<String>,
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,9 +71,9 @@ pub struct MihomoConfig {
     mode: MihomoMode,
     log_level: MihomoLogLevel,
     ipv6: Option<bool>,
-    external_controller: Option<String>,
+    pub external_controller: Option<String>,
     pub external_ui: Option<String>,
-    secret: Option<String>,
+    pub secret: Option<String>,
     pub geodata_mode: Option<bool>,
     pub geo_auto_update: Option<bool>,
     pub geo_update_interval: Option<u16>,
@@ -163,39 +163,61 @@ impl Config {
     }
 }
 
+/// Load config from path without validation.  Returns `Ok(None)` if the file does not exist.
+pub fn load_config(path: &str) -> Result<Option<Config>> {
+    let config_path = Path::new(path);
+    if !config_path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(Config::setup_from(path)?))
+}
+
+/// Write default config to path if it does not exist.  Returns `true` if the file was created.
+pub fn write_default_if_missing(path: &str) -> Result<bool> {
+    let config_path = Path::new(path);
+    create_parent_dir(config_path)?;
+    if config_path.exists() {
+        return Ok(false);
+    }
+    Config::new().write(config_path)?;
+    Ok(true)
+}
+
+/// Validate that required config fields are non-empty.
+pub fn validate_config(config: &Config) -> Result<()> {
+    let required_fields = [
+        ("remote_config_url", &config.remote_config_url),
+        ("mihomo_binary_path", &config.mihomo_binary_path),
+        ("mihomo_config_root", &config.mihomo_config_root),
+        ("user_systemd_root", &config.user_systemd_root),
+    ];
+    for (field, value) in required_fields.iter() {
+        if value.is_empty() {
+            bail!("`{}` undefined", field);
+        }
+    }
+    Ok(())
+}
+
 /// Tries to parse mihoro config as toml from path.
 ///
-/// * If config file does not exist, creates default config file to path and returns error.
-/// * If found, tries to parse the file and returns error if parse fails or fields found undefined.
+/// * If config file does not exist, creates default config file and returns an error directing
+///   the user to run `mihoro init`.
+/// * If found, parses the file and validates required fields.
 pub fn parse_config(path: &str) -> Result<Config> {
-    // Create mihoro default config if not exists
     let config_path = Path::new(path);
     create_parent_dir(config_path)?;
 
     if !config_path.exists() {
         Config::new().write(config_path)?;
         bail!(
-            "created default config at `{path}`, run again to finish setup",
-            path = path.underline()
+            "created default config at `{}`, run `mihoro init` to finish setup",
+            path.underline()
         );
     }
 
-    // Parse config file
     let config = Config::setup_from(path)?;
-    let required_urls = [
-        ("remote_config_url", &config.remote_config_url),
-        ("mihomo_binary_path", &config.mihomo_binary_path),
-        ("mihomo_config_root", &config.mihomo_config_root),
-        ("user_systemd_root", &config.user_systemd_root),
-    ];
-
-    // Validate if urls are defined
-    for (field, value) in required_urls.iter() {
-        if value.is_empty() {
-            bail!("`{}` undefined", field)
-        }
-    }
-
+    validate_config(&config)?;
     Ok(config)
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,296 @@
+use crate::config::{load_config, validate_config, write_default_if_missing, Config};
+use crate::mihoro::{BinaryPlan, Mihoro, StageStatus};
+
+use std::{future::Future, path::Path};
+
+use anyhow::{bail, Result};
+use colored::Colorize;
+use dialoguer::Input;
+use reqwest::Client;
+use shellexpand::tilde;
+
+pub struct InitOptions {
+    pub force: bool,
+    pub arch: Option<String>,
+    pub yes: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Stage report
+// ---------------------------------------------------------------------------
+
+struct StageReport {
+    entries: Vec<(&'static str, StageStatus)>,
+}
+
+impl StageReport {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Print the stage header and optional first detail line.
+    fn begin(&self, name: &'static str, description: Option<&str>) {
+        println!("{} {}", "●".cyan().bold(), name.bold());
+        if let Some(description) = description {
+            println!("{}  {}", " ⎿".cyan().bold(), description.italic().dimmed());
+        }
+    }
+
+    async fn run<F, Fut>(&mut self, name: &'static str, description: Option<&str>, f: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<StageStatus>>,
+    {
+        self.begin(name, description);
+        let status = match f().await {
+            Ok(s) => s,
+            Err(e) => StageStatus::Failed(e),
+        };
+        self.entries.push((name, status));
+    }
+
+    /// Record a pre-computed status without printing a header.  Pair with
+    /// [`Self::begin`] for stages whose header must appear *before* the work runs
+    /// (e.g. the binary download / install split, where ownership constraints
+    /// make the closure pattern awkward).
+    fn record(&mut self, name: &'static str, status: StageStatus) {
+        self.entries.push((name, status));
+    }
+
+    fn print(&self) {
+        println!("{} {}", "mihoro:".cyan().bold(), "init summary".bold());
+        for (name, status) in &self.entries {
+            match status {
+                StageStatus::Installed => {
+                    println!("  {} {}", "✓".green().bold(), name);
+                }
+                StageStatus::Skipped(reason) => {
+                    println!("  {} {} ({})", "↷".dimmed(), name.dimmed(), reason.dimmed());
+                }
+                StageStatus::Failed(err) => {
+                    println!("  {} {}: {:#}", "✗".red().bold(), name.red(), err);
+                }
+            }
+        }
+    }
+
+    fn has_failures(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|(_, s)| matches!(s, StageStatus::Failed(_)))
+    }
+
+    fn stage_failed(&self, name: &'static str) -> bool {
+        self.entries
+            .iter()
+            .any(|(n, s)| *n == name && matches!(s, StageStatus::Failed(_)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard URL helper
+// ---------------------------------------------------------------------------
+
+fn dashboard_url(config: &Config) -> Option<String> {
+    let controller = config.mihomo_config.external_controller.as_deref()?;
+    let (host, port) = controller.rsplit_once(':')?;
+    let host = match host {
+        "0.0.0.0" | "[::]" | "" => "127.0.0.1",
+        h => h,
+    };
+    Some(format!("http://{host}:{port}/ui/"))
+}
+
+// ---------------------------------------------------------------------------
+// Interactive bootstrap
+// ---------------------------------------------------------------------------
+
+fn prompt_subscription_url() -> Result<String> {
+    let url: String = Input::new()
+        .with_prompt("Remote subscription URL")
+        .validate_with(|s: &String| {
+            if s.trim().is_empty() {
+                Err("URL cannot be empty")
+            } else {
+                Ok(())
+            }
+        })
+        .interact_text()?;
+    Ok(url.trim().to_string())
+}
+
+fn bootstrap_config(config_path: &str, yes: bool) -> Result<Config> {
+    let just_created = write_default_if_missing(config_path)?;
+
+    // After write_default_if_missing the file always exists.
+    let mut config =
+        load_config(config_path)?.expect("config file must exist after write_default_if_missing");
+
+    if config.remote_config_url.is_empty() {
+        if yes {
+            bail!(
+                "`remote_config_url` is not set - edit `{}` or run `mihoro init` interactively",
+                config_path
+            );
+        }
+
+        if just_created {
+            println!(
+                "{} Created default config at {}",
+                "mihoro:".cyan(),
+                config_path.underline().yellow()
+            );
+        }
+        println!("{} Enter your remote subscription URL:", "mihoro:".yellow());
+        config.remote_config_url = prompt_subscription_url()?;
+        config.write(Path::new(config_path))?;
+        println!("{} Saved", "mihoro:".green());
+    }
+
+    Ok(config)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Result<()> {
+    let config_path = tilde(config_path);
+    let config_path = config_path.as_ref();
+    let config = bootstrap_config(config_path, opts.yes)?;
+    validate_config(&config)?;
+
+    let mihoro = Mihoro::from_config(config.clone());
+
+    println!("{} initializing", "mihoro:".cyan().bold());
+
+    let force = opts.force;
+    let arch = opts.arch.as_deref();
+    let mut report = StageReport::new();
+
+    // --- download phase -------------------------------------------------------
+    //
+    // Binary is downloaded first so that the running mihomo proxy is still alive
+    // for subsequent requests (config / geodata / UI may all go through
+    // https_proxy=http://127.0.0.1:<port>).  The actual service stop + binary
+    // swap is deferred to the "install binary" stage after all downloads finish.
+
+    report.begin(
+        "mihomo binary",
+        Some("Resolve the target build and download the mihomo release archive"),
+    );
+    let binary_temp = match mihoro.prepare_binary(client, force, arch).await {
+        Ok(BinaryPlan::Install(temp)) => {
+            report.record("mihomo binary", StageStatus::Installed);
+            Some(temp)
+        }
+        Ok(BinaryPlan::Skip(reason)) => {
+            report.record("mihomo binary", StageStatus::Skipped(reason));
+            None
+        }
+        Err(e) => {
+            report.record("mihomo binary", StageStatus::Failed(e));
+            None
+        }
+    };
+
+    report
+        .run(
+            "remote config",
+            Some("Download the remote config and apply local mihoro.toml overrides"),
+            || mihoro.ensure_remote_config(client, force),
+        )
+        .await;
+    report
+        .run(
+            "geodata",
+            Some("Download geoip / geosite data files required by mihomo"),
+            || mihoro.ensure_geodata(client, force),
+        )
+        .await;
+    report
+        .run(
+            "web dashboard",
+            Some("Download and install the configured web UI assets"),
+            || mihoro.ensure_ui(client, force),
+        )
+        .await;
+
+    // --- install phase --------------------------------------------------------
+    //
+    // All network calls are done.  Now it is safe to stop the running service
+    // (which also tears down the proxy) and swap in the new binary.
+    //
+    // If the remote config stage failed we must not proceed: installing a new
+    // binary or restarting the service on top of a missing / corrupt config.yaml
+    // would break an environment that may have been working before.
+
+    if report.stage_failed("remote config") {
+        let skip = || StageStatus::Skipped("skipped: remote config stage failed".to_string());
+        report.record("install binary", skip());
+        report.record("systemd service", skip());
+        report.record("service start", skip());
+    } else {
+        report.begin(
+            "install binary",
+            Some("Install the downloaded mihomo binary into the configured path"),
+        );
+        let install_status = match binary_temp {
+            None => StageStatus::Skipped("nothing to install".to_string()),
+            Some(temp) => match mihoro.install_binary(temp).await {
+                Ok(s) => s,
+                Err(e) => StageStatus::Failed(e),
+            },
+        };
+        report.record("install binary", install_status);
+
+        report
+            .run("systemd service", None, || async {
+                mihoro.ensure_service().await
+            })
+            .await;
+        report
+            .run("service start", None, || async {
+                mihoro.ensure_service_running().await
+            })
+            .await;
+    }
+
+    report.print();
+
+    // Print dashboard URL if UI is configured
+    if config.ui.is_some() {
+        if let Some(url) = dashboard_url(&config) {
+            println!();
+            println!("  {}: {}", "Dashboard".bold(), url.underline().cyan());
+            let ui_name = config
+                .ui
+                .as_ref()
+                .map(|u| u.as_config_value())
+                .unwrap_or("ui");
+            println!(
+                "  Using {} - change via the {} field in {}",
+                ui_name.bold(),
+                "`ui`".bold(),
+                "mihoro.toml".underline()
+            );
+            if config.mihomo_config.secret.is_some() {
+                println!("  Authentication required (secret is set in mihoro.toml)");
+            } else {
+                println!(
+                    "  Set {} in {} to require a password",
+                    "`mihomo_config.secret`".bold(),
+                    "mihoro.toml".underline()
+                );
+            }
+        }
+    }
+
+    if report.has_failures() {
+        bail!("one or more stages failed - see summary above");
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cmd;
 mod config;
 mod cron;
+mod init;
 mod mihoro;
 mod proxy;
 mod resolve_mihomo_bin;
@@ -18,11 +19,70 @@ use clap_complete::{
 };
 use colored::Colorize;
 use reqwest::Client;
-use std::{io, process::Command};
+use std::{future::Future, io, process::Command, time::Duration};
 
 use cmd::{Args, ClapShell, Commands};
-use mihoro::Mihoro;
+use mihoro::{Mihoro, StageStatus};
 use systemctl::Systemctl;
+
+struct StageReport {
+    entries: Vec<(&'static str, StageStatus)>,
+}
+
+impl StageReport {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    fn begin(&self, name: &'static str, description: Option<&str>) {
+        println!("{} {}", "●".cyan().bold(), name.bold());
+        if let Some(description) = description {
+            println!("{}  {}", " ⎿".cyan().bold(), description.italic().dimmed());
+        }
+    }
+
+    async fn run<F, Fut>(&mut self, name: &'static str, description: Option<&str>, f: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<StageStatus>>,
+    {
+        self.begin(name, description);
+        let status = match f().await {
+            Ok(status) => status,
+            Err(err) => StageStatus::Failed(err),
+        };
+        self.entries.push((name, status));
+    }
+
+    fn record(&mut self, name: &'static str, status: StageStatus) {
+        self.entries.push((name, status));
+    }
+
+    fn print(&self, label: &str) {
+        println!("{} {}", "mihoro:".cyan().bold(), label.bold());
+        for (name, status) in &self.entries {
+            match status {
+                StageStatus::Installed => {
+                    println!("  {} {}", "✓".green().bold(), name);
+                }
+                StageStatus::Skipped(reason) => {
+                    println!("  {} {} ({})", "↷".dimmed(), name.dimmed(), reason.dimmed());
+                }
+                StageStatus::Failed(err) => {
+                    println!("  {} {}: {:#}", "✗".red().bold(), name.red(), err);
+                }
+            }
+        }
+    }
+
+    fn has_failures(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|(_, status)| matches!(status, StageStatus::Failed(_)))
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -34,13 +94,48 @@ async fn main() {
 
 async fn cli() -> Result<()> {
     let args = Args::parse();
-    let client = Client::new();
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .read_timeout(Duration::from_secs(30))
+        .build()?;
+
+    // Handle Init and Setup before constructing Mihoro, which requires a valid config.
+    match &args.command {
+        Some(Commands::Init { force, arch, yes }) => {
+            return init::run(
+                &args.mihoro_config,
+                &client,
+                init::InitOptions {
+                    force: *force,
+                    arch: arch.clone(),
+                    yes: *yes,
+                },
+            )
+            .await;
+        }
+        Some(Commands::Setup { overwrite, arch }) => {
+            eprintln!(
+                "{} `setup` is deprecated - use `mihoro init` instead",
+                "warning:".yellow()
+            );
+            return init::run(
+                &args.mihoro_config,
+                &client,
+                init::InitOptions {
+                    force: *overwrite,
+                    arch: arch.clone(),
+                    yes: true,
+                },
+            )
+            .await;
+        }
+        _ => {}
+    }
+
     let mihoro = Mihoro::new(&args.mihoro_config)?;
 
     match &args.command {
-        Some(Commands::Setup { overwrite, arch }) => {
-            mihoro.setup(client, *overwrite, arch.as_deref()).await?
-        }
+        Some(Commands::Init { .. }) | Some(Commands::Setup { .. }) => unreachable!(),
         Some(Commands::Update {
             config,
             core,
@@ -49,50 +144,105 @@ async fn cli() -> Result<()> {
             arch,
             ui,
         }) => {
+            println!("{} update", "mihoro:".cyan().bold());
+            let mut report = StageReport::new();
+
             if *all {
-                // Update config (without restarting yet)
-                println!(
-                    "{} Updating config...",
-                    mihoro.prefix.magenta().bold().italic()
-                );
-                if let Err(e) = mihoro.update_config(&client, false).await {
-                    eprintln!("{} Failed to update config: {}", mihoro.prefix.yellow(), e);
+                report
+                    .run(
+                        "config",
+                        Some("Download the remote config and apply local overrides"),
+                        || mihoro.update_config(&client),
+                    )
+                    .await;
+                report
+                    .run(
+                        "geodata",
+                        Some("Refresh geoip / geosite data used by mihomo"),
+                        || mihoro.update_geodata(&client),
+                    )
+                    .await;
+                report
+                    .run(
+                        "ui",
+                        Some("Download and install the configured web dashboard"),
+                        || mihoro.update_ui(&client),
+                    )
+                    .await;
+                report
+                    .run(
+                        "core",
+                        Some("Download and install the latest mihomo core binary"),
+                        || mihoro.update_core(&client, arch.as_deref()),
+                    )
+                    .await;
+                if !report.has_failures() {
+                    report
+                        .run("service restart", None, || mihoro.restart_service())
+                        .await;
+                } else {
+                    report.record(
+                        "service restart",
+                        StageStatus::Skipped("skipped due to earlier failures".to_string()),
+                    );
                 }
-                // Update geodata
-                println!(
-                    "{} Updating geodata...",
-                    mihoro.prefix.magenta().bold().italic()
-                );
-                if let Err(e) = mihoro.update_geodata(&client).await {
-                    eprintln!("{} Failed to update geodata: {}", mihoro.prefix.yellow(), e);
-                }
-                // Update core (without restarting yet)
-                println!(
-                    "{} Updating core...",
-                    mihoro.prefix.magenta().bold().italic()
-                );
-                if let Err(e) = mihoro.update_core(&client, arch.as_deref(), false).await {
-                    eprintln!("{} Failed to update core: {}", mihoro.prefix.yellow(), e);
-                }
-                println!("{} Updating UI...", mihoro.prefix.magenta().bold().italic());
-                if let Err(e) = mihoro.update_ui(&client).await {
-                    eprintln!("{} Failed to update UI: {}", mihoro.prefix.yellow(), e);
-                }
-                // Restart service once at the end
-                println!(
-                    "{} Restarting mihomo.service...",
-                    mihoro.prefix.green().bold().italic()
-                );
-                Systemctl::new().restart("mihomo.service").execute()?;
             } else if *core {
-                mihoro.update_core(&client, arch.as_deref(), true).await?;
+                report
+                    .run(
+                        "core",
+                        Some("Download and install the latest mihomo core binary"),
+                        || mihoro.update_core(&client, arch.as_deref()),
+                    )
+                    .await;
+                if !report.has_failures() {
+                    report
+                        .run("service restart", None, || mihoro.restart_service())
+                        .await;
+                } else {
+                    report.record(
+                        "service restart",
+                        StageStatus::Skipped("skipped due to earlier failures".to_string()),
+                    );
+                }
             } else if *ui {
-                mihoro.update_ui(&client).await?;
+                report
+                    .run(
+                        "ui",
+                        Some("Download and install the configured web dashboard"),
+                        || mihoro.update_ui(&client),
+                    )
+                    .await;
             } else if *geodata {
-                mihoro.update_geodata(&client).await?;
+                report
+                    .run(
+                        "geodata",
+                        Some("Refresh geoip / geosite data used by mihomo"),
+                        || mihoro.update_geodata(&client),
+                    )
+                    .await;
             } else if *config || (!*core && !*geodata && !*ui) {
-                // Explicit --config or default (no flags)
-                mihoro.update_config(&client, true).await?;
+                report
+                    .run(
+                        "config",
+                        Some("Download the remote config and apply local overrides"),
+                        || mihoro.update_config(&client),
+                    )
+                    .await;
+                if !report.has_failures() {
+                    report
+                        .run("service restart", None, || mihoro.restart_service())
+                        .await;
+                } else {
+                    report.record(
+                        "service restart",
+                        StageStatus::Skipped("skipped due to earlier failures".to_string()),
+                    );
+                }
+            }
+
+            report.print("update summary");
+            if report.has_failures() {
+                anyhow::bail!("one or more update stages failed - see summary above");
             }
         }
         Some(Commands::Apply) => mihoro.apply().await?,

--- a/src/mihoro.rs
+++ b/src/mihoro.rs
@@ -271,7 +271,9 @@ impl Mihoro {
         let is_enabled = Systemctl::is_enabled("mihomo.service");
 
         if is_active && is_enabled {
-            return Ok(StageStatus::Skipped("already running and enabled".to_string()));
+            return Ok(StageStatus::Skipped(
+                "already running and enabled".to_string(),
+            ));
         }
 
         if !is_enabled {

--- a/src/mihoro.rs
+++ b/src/mihoro.rs
@@ -7,7 +7,10 @@ use crate::systemctl::Systemctl;
 use crate::ui::{install_ui, resolve_external_ui_path};
 use crate::utils::{
     create_parent_dir, delete_file, download_file, extract_gzip, try_decode_base64_file_inplace,
+    DETAIL_PREFIX,
 };
+
+use anyhow::Error;
 
 use std::fs;
 use std::os::unix::prelude::PermissionsExt;
@@ -33,12 +36,36 @@ pub struct Mihoro {
     pub mihomo_target_service_path: String,
 }
 
+/// Outcome of a single setup stage, used by `mihoro init`.
+pub enum StageStatus {
+    Installed,
+    Skipped(String),
+    Failed(Error),
+}
+
+/// Plan returned by [`Mihoro::prepare_binary`]: either we already have the binary and
+/// nothing needs swapping, or we downloaded a new one to a temp file that the install
+/// step must consume.
+///
+/// The split exists so the network-killing `Systemctl::stop` happens only after every
+/// other download stage has finished - otherwise the still-running mihomo proxy gets
+/// torn down mid-init and subsequent reqwest calls hit `Connection refused` against
+/// the configured `https_proxy`.
+pub enum BinaryPlan {
+    Skip(String),
+    Install(NamedTempFile),
+}
+
 impl Mihoro {
-    pub fn new(config_path: &String) -> Result<Mihoro> {
-        let config = parse_config(tilde(&config_path).as_ref())?;
-        Ok(Mihoro {
+    pub fn new(config_path: &str) -> Result<Mihoro> {
+        let config = parse_config(tilde(config_path).as_ref())?;
+        Ok(Self::from_config(config))
+    }
+
+    /// Build a `Mihoro` from an already-validated `Config`.
+    pub fn from_config(config: Config) -> Mihoro {
+        Mihoro {
             prefix: String::from("mihoro:"),
-            config: config.clone(),
             mihomo_target_binary_path: tilde(&config.mihomo_binary_path).to_string(),
             mihomo_target_config_root: tilde(&config.mihomo_config_root).to_string(),
             mihomo_target_config_path: tilde(&format!("{}/config.yaml", config.mihomo_config_root))
@@ -48,123 +75,224 @@ impl Mihoro {
                 config.user_systemd_root
             ))
             .to_string(),
-        })
+            config,
+        }
     }
 
-    pub async fn setup(
+    /// Stage 1 of the binary install: resolve the URL and download to a temp file.
+    ///
+    /// Skips if the binary exists and `force` is false. The returned [`BinaryPlan`] is
+    /// handed to [`Mihoro::install_binary`] *after* every other download stage so that
+    /// stopping the running mihomo service does not break the user's `https_proxy`
+    /// while we still need to reach the network.
+    pub async fn prepare_binary(
         &self,
-        client: Client,
-        overwrite_binary: bool,
+        client: &Client,
+        force: bool,
         arch_override: Option<&str>,
-    ) -> Result<()> {
-        println!(
-            "{} Setting up mihomo's binary, config, and systemd service...",
-            &self.prefix.cyan()
-        );
-
-        // Setup mihomo binary at `mihomo_target_binary_path`
+    ) -> Result<BinaryPlan> {
         let binary_exists = fs::metadata(&self.mihomo_target_binary_path).is_ok();
-        if binary_exists && !overwrite_binary {
-            println!(
-                "{} Assuming mihomo binary already installed at {}, skipping setup",
-                self.prefix.yellow(),
-                self.mihomo_target_binary_path.underline().green()
-            );
-        } else {
-            if binary_exists {
-                println!(
-                    "{} Overwriting existing mihomo binary at {}",
-                    self.prefix.yellow(),
-                    self.mihomo_target_binary_path.underline().green()
-                );
-            }
-
-            // Resolve binary URL (auto-detect from GitHub or use configured URL)
-            let binary_url = resolve_mihomo_bin::resolve_binary_url(
-                &client,
-                &self.config,
-                arch_override,
-                &self.prefix,
-            )
-            .await?;
-
-            // Create a temporary file for downloading
-            let temp_file = NamedTempFile::new()?;
-            let temp_path = temp_file.path();
-
-            // Download mihomo binary and set permission to executable
-            download_file(
-                &client,
-                &binary_url,
-                temp_path,
-                &self.config.mihoro_user_agent,
-            )
-            .await?;
-
-            // Try to extract the binary, handle "Text file busy" error if overwriting
-            match extract_gzip(temp_path, &self.mihomo_target_binary_path, &self.prefix) {
-                Ok(_) => {
-                    // Set executable permission
-                    let executable = fs::Permissions::from_mode(0o755);
-                    fs::set_permissions(&self.mihomo_target_binary_path, executable)?;
-                }
-                Err(e) => {
-                    // Handle "Text file busy" error
-                    return Err(if e.to_string().contains("Text file busy") {
-                        anyhow!("Failed to overwrite as `mihomo` is in use, stop the service first")
-                    } else {
-                        e
-                    });
-                }
-            };
+        if binary_exists && !force {
+            return Ok(BinaryPlan::Skip(format!(
+                "binary exists at {}",
+                self.mihomo_target_binary_path
+            )));
         }
-
-        // Download remote mihomo config and apply override
-        download_file(
-            &client,
-            &self.config.remote_config_url,
-            Path::new(&self.mihomo_target_config_path),
-            &self.config.mihoro_user_agent,
+        let binary_url = resolve_mihomo_bin::resolve_binary_url(
+            client,
+            &self.config,
+            arch_override,
+            DETAIL_PREFIX,
         )
         .await?;
 
-        // Try to decode base64 file in place if file is base64 encoding, otherwise do nothing
+        let temp_file = NamedTempFile::new()?;
+        download_file(
+            client,
+            &binary_url,
+            temp_file.path(),
+            &self.config.mihoro_user_agent,
+        )
+        .await?;
+        Ok(BinaryPlan::Install(temp_file))
+    }
+
+    /// Stage 2 of the binary install: stop the running service if any, then extract the
+    /// downloaded binary into place and set its executable bit.
+    ///
+    /// Must run *after* every other network-dependent stage; see [`BinaryPlan`].
+    pub async fn install_binary(&self, temp_file: NamedTempFile) -> Result<StageStatus> {
+        // Stop the service before overwriting to avoid "Text file busy".
+        let binary_exists = fs::metadata(&self.mihomo_target_binary_path).is_ok();
+        if binary_exists {
+            println!(
+                "{} Stopping mihomo.service before overwriting binary...",
+                DETAIL_PREFIX.cyan()
+            );
+            Systemctl::new().stop("mihomo.service").execute()?;
+        }
+
+        extract_gzip(
+            temp_file.path(),
+            &self.mihomo_target_binary_path,
+            DETAIL_PREFIX.cyan(),
+        )?;
+        let executable = fs::Permissions::from_mode(0o755);
+        fs::set_permissions(&self.mihomo_target_binary_path, executable)?;
+        Ok(StageStatus::Installed)
+    }
+
+    /// Download remote config YAML and apply TOML overrides.
+    /// If the config file already exists and `force` is false, only re-applies overrides.
+    pub async fn ensure_remote_config(&self, client: &Client, force: bool) -> Result<StageStatus> {
+        let config_path = Path::new(&self.mihomo_target_config_path);
+        if !force && config_path.exists() {
+            // Re-apply TOML overrides onto the cached YAML so user changes take effect.
+            apply_mihomo_override(&self.mihomo_target_config_path, &self.config.mihomo_config)?;
+            return Ok(StageStatus::Installed);
+        }
+
+        download_file(
+            client,
+            &self.config.remote_config_url,
+            config_path,
+            &self.config.mihoro_user_agent,
+        )
+        .await?;
         try_decode_base64_file_inplace(&self.mihomo_target_config_path)?;
-
         apply_mihomo_override(&self.mihomo_target_config_path, &self.config.mihomo_config)?;
+        Ok(StageStatus::Installed)
+    }
 
-        // Download geodata
-        self.update_geodata(&client).await?;
+    /// Download geodata.  Skips files that already exist (unless `force`).
+    pub async fn ensure_geodata(&self, client: &Client, force: bool) -> Result<StageStatus> {
+        let Some(ref geox_url) = self.config.mihomo_config.geox_url else {
+            return Ok(StageStatus::Skipped("geox_url not configured".to_string()));
+        };
 
-        // Install external UI assets if configured
-        self.update_ui(&client).await?;
+        let geodata_mode = self.config.mihomo_config.geodata_mode.unwrap_or(false);
+        let config_root = Path::new(&self.mihomo_target_config_root);
 
-        // Create mihomo.service systemd file
-        create_mihomo_service(
+        if geodata_mode {
+            let geoip_path = config_root.join("geoip.dat");
+            let geosite_path = config_root.join("geosite.dat");
+            if !force && geoip_path.exists() && geosite_path.exists() {
+                return Ok(StageStatus::Skipped("geodata present".to_string()));
+            }
+            if force || !geoip_path.exists() {
+                download_file(
+                    client,
+                    &geox_url.geoip,
+                    &geoip_path,
+                    &self.config.mihoro_user_agent,
+                )
+                .await?;
+            }
+            if force || !geosite_path.exists() {
+                download_file(
+                    client,
+                    &geox_url.geosite,
+                    &geosite_path,
+                    &self.config.mihoro_user_agent,
+                )
+                .await?;
+            }
+        } else {
+            let mmdb_path = config_root.join("country.mmdb");
+            if !force && mmdb_path.exists() {
+                return Ok(StageStatus::Skipped("geodata present".to_string()));
+            }
+            download_file(
+                client,
+                &geox_url.mmdb,
+                &mmdb_path,
+                &self.config.mihoro_user_agent,
+            )
+            .await?;
+        }
+
+        Ok(StageStatus::Installed)
+    }
+
+    /// Install the web dashboard.  Skips if the target directory already has an `index.html`
+    /// (unless `force`).
+    pub async fn ensure_ui(&self, client: &Client, force: bool) -> Result<StageStatus> {
+        let Some(ui) = self.config.ui.as_ref() else {
+            return Ok(StageStatus::Skipped("UI management disabled".to_string()));
+        };
+        let Some(target_dir) = self.external_ui_target_dir() else {
+            return Ok(StageStatus::Skipped("`external_ui` path unset".to_string()));
+        };
+        if !force && target_dir.join("index.html").exists() {
+            return Ok(StageStatus::Skipped(format!(
+                "{} already installed",
+                ui.as_config_value()
+            )));
+        }
+        install_ui(
+            client,
+            ui,
+            &target_dir,
+            &self.config.mihoro_user_agent,
+            DETAIL_PREFIX.cyan(),
+        )
+        .await?;
+        Ok(StageStatus::Installed)
+    }
+
+    /// Write the systemd unit file.  Skips if the file already exists with identical content.
+    pub async fn ensure_service(&self) -> Result<StageStatus> {
+        let service_content = render_service_string(
             &self.mihomo_target_binary_path,
             &self.mihomo_target_config_root,
-            &self.mihomo_target_service_path,
-            &self.prefix,
-        )?;
+        );
+        if let Ok(existing) = fs::read_to_string(&self.mihomo_target_service_path) {
+            if existing == service_content {
+                return Ok(StageStatus::Skipped("service file unchanged".to_string()));
+            }
+        }
+        create_parent_dir(Path::new(&self.mihomo_target_service_path))?;
+        fs::write(&self.mihomo_target_service_path, &service_content)?;
+        Systemctl::new().daemon_reload().execute()?;
+        println!(
+            "{} Created mihomo.service at {}",
+            DETAIL_PREFIX.cyan(),
+            self.mihomo_target_service_path.underline().yellow()
+        );
+        Ok(StageStatus::Installed)
+    }
 
-        Systemctl::new().enable("mihomo.service").execute()?;
-        Systemctl::new().start("mihomo.service").execute()?;
-        Ok(())
+    /// Enable and start mihomo.service, ensuring both autostart and current-session state.
+    ///
+    /// Always enables the service so it survives reboots, even if it was already running but
+    /// not enabled (e.g. started manually after a previous failed init).
+    pub async fn ensure_service_running(&self) -> Result<StageStatus> {
+        let is_active = Systemctl::is_active("mihomo.service");
+        let is_enabled = Systemctl::is_enabled("mihomo.service");
+
+        if is_active && is_enabled {
+            return Ok(StageStatus::Skipped("already running and enabled".to_string()));
+        }
+
+        if !is_enabled {
+            Systemctl::new().enable("mihomo.service").execute()?;
+        }
+        if !is_active {
+            Systemctl::new().start("mihomo.service").execute()?;
+        }
+        Ok(StageStatus::Installed)
     }
 
     pub async fn update_core(
         &self,
         client: &Client,
         arch_override: Option<&str>,
-        restart: bool,
-    ) -> Result<()> {
-        println!("{} Updating mihomo core binary...", &self.prefix.cyan());
-
+    ) -> Result<StageStatus> {
         // Check if binary exists
         let binary_exists = fs::metadata(&self.mihomo_target_binary_path).is_ok();
         if !binary_exists {
             return Err(anyhow!(
-                "Mihomo binary not found at {}. Run `mihoro setup` first.",
+                "Mihomo binary not found at {}. Run `mihoro init` first.",
                 self.mihomo_target_binary_path
             ));
         }
@@ -174,7 +302,7 @@ impl Mihoro {
             client,
             &self.config,
             arch_override,
-            &self.prefix,
+            DETAIL_PREFIX,
         )
         .await?;
 
@@ -194,33 +322,25 @@ impl Mihoro {
         // Stop the service before overwriting binary to avoid "Text file busy" error
         println!(
             "{} Stopping mihomo.service before overwriting...",
-            self.prefix.yellow()
+            DETAIL_PREFIX.yellow()
         );
         Systemctl::new().stop("mihomo.service").execute()?;
 
         // Extract and overwrite the binary
-        extract_gzip(temp_path, &self.mihomo_target_binary_path, &self.prefix)?;
+        extract_gzip(
+            temp_path,
+            &self.mihomo_target_binary_path,
+            DETAIL_PREFIX.cyan(),
+        )?;
 
         // Set executable permission
         let executable = fs::Permissions::from_mode(0o755);
         fs::set_permissions(&self.mihomo_target_binary_path, executable)?;
 
-        println!(
-            "{} Updated mihomo binary at {}",
-            self.prefix.green(),
-            self.mihomo_target_binary_path.underline().yellow()
-        );
-
-        // Restart the service if requested
-        if restart {
-            println!("{} Restarting mihomo.service...", self.prefix.green());
-            Systemctl::new().start("mihomo.service").execute()?;
-        }
-
-        Ok(())
+        Ok(StageStatus::Installed)
     }
 
-    pub async fn update_config(&self, client: &Client, restart: bool) -> Result<()> {
+    pub async fn update_config(&self, client: &Client) -> Result<StageStatus> {
         // Download remote mihomo config and apply override
         download_file(
             client,
@@ -236,18 +356,12 @@ impl Mihoro {
         apply_mihomo_override(&self.mihomo_target_config_path, &self.config.mihomo_config)?;
         println!(
             "{} Updated and applied config overrides",
-            self.prefix.yellow()
+            DETAIL_PREFIX.cyan()
         );
-
-        // Restart mihomo systemd service if requested
-        if restart {
-            println!("{} Restart mihomo.service", self.prefix.green());
-            Systemctl::new().restart("mihomo.service").execute()?;
-        }
-        Ok(())
+        Ok(StageStatus::Installed)
     }
 
-    pub async fn update_geodata(&self, client: &Client) -> Result<()> {
+    pub async fn update_geodata(&self, client: &Client) -> Result<StageStatus> {
         if let Some(geox_url) = self.config.mihomo_config.geox_url.clone() {
             // Download geodata files based on `geodata_mode`
             let geodata_mode = self.config.mihomo_config.geodata_mode.unwrap_or(false);
@@ -276,45 +390,37 @@ impl Mihoro {
                 .await?;
             }
 
-            println!("{} Downloaded and updated geodata", self.prefix.green());
+            println!("{} Downloaded and updated geodata", DETAIL_PREFIX.cyan());
         } else {
-            println!(
-                "{} `geox_url` undefined, refer to {}",
-                self.prefix.yellow(),
-                "'https://wiki.metacubex.one/config/general/#geo_3'"
-                    .bold()
-                    .underline()
-            );
+            return Ok(StageStatus::Skipped("`geox_url` undefined".to_string()));
         }
-        Ok(())
+        Ok(StageStatus::Installed)
     }
 
-    pub async fn update_ui(&self, client: &Client) -> Result<()> {
+    pub async fn update_ui(&self, client: &Client) -> Result<StageStatus> {
         let Some(ui) = self.config.ui.as_ref() else {
-            println!("{} UI management disabled, skipping", self.prefix.yellow());
-            return Ok(());
+            return Ok(StageStatus::Skipped("UI management disabled".to_string()));
         };
 
         let Some(target_dir) = self.external_ui_target_dir() else {
-            println!(
-                "{} `external_ui` undefined, skipping UI installation",
-                self.prefix.yellow()
-            );
-            return Ok(());
+            return Ok(StageStatus::Skipped("`external_ui` undefined".to_string()));
         };
 
-        println!(
-            "{} Updating external UI assets...",
-            self.prefix.cyan().bold()
-        );
         install_ui(
             client,
             ui,
             &target_dir,
             &self.config.mihoro_user_agent,
-            &self.prefix.green(),
+            DETAIL_PREFIX.cyan(),
         )
-        .await
+        .await?;
+        Ok(StageStatus::Installed)
+    }
+
+    pub async fn restart_service(&self) -> Result<StageStatus> {
+        println!("{} Restarting mihomo.service...", DETAIL_PREFIX.cyan());
+        Systemctl::new().restart("mihomo.service").execute()?;
+        Ok(StageStatus::Installed)
     }
 
     pub async fn apply(&self) -> Result<()> {
@@ -342,8 +448,8 @@ impl Mihoro {
         Systemctl::new().stop("mihomo.service").execute()?;
         Systemctl::new().disable("mihomo.service").execute()?;
 
-        delete_file(&self.mihomo_target_service_path, &self.prefix)?;
-        delete_file(&self.mihomo_target_config_path, &self.prefix)?;
+        delete_file(&self.mihomo_target_service_path, self.prefix.cyan())?;
+        delete_file(&self.mihomo_target_config_path, self.prefix.cyan())?;
 
         Systemctl::new().daemon_reload().execute()?;
         Systemctl::new().reset_failed().execute()?;
@@ -433,19 +539,11 @@ impl Mihoro {
     }
 }
 
-/// Create a systemd service file for running mihomo as a service.
-///
-/// By default, user systemd services are created under `~/.config/systemd/user/mihomo.service` and
-/// invoked with `systemctl --user start mihomo.service`. Directory is created if not present.
+/// Render the systemd unit file content for the mihomo service.
 ///
 /// Reference: https://wiki.metacubex.one/startup/service/
-fn create_mihomo_service(
-    mihomo_binary_path: &str,
-    mihomo_config_root: &str,
-    mihomo_service_path: &str,
-    prefix: &str,
-) -> Result<()> {
-    let service = format!(
+fn render_service_string(binary_path: &str, config_root: &str) -> String {
+    format!(
         "[Unit]
 Description=mihomo Daemon, Another Clash Kernel.
 After=network.target NetworkManager.service systemd-networkd.service iwd.service
@@ -461,21 +559,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=default.target",
-        mihomo_binary_path, mihomo_config_root
-    );
-
-    // Create mihomo service directory if not exists
-    create_parent_dir(Path::new(mihomo_service_path))?;
-
-    // Write mihomo.service contents to file
-    fs::write(mihomo_service_path, service)?;
-
-    println!(
-        "{} Created mihomo.service at {}",
-        prefix.green(),
-        mihomo_service_path.underline().yellow()
-    );
-    Ok(())
+        binary_path, config_root
+    )
 }
 
 #[cfg(test)]

--- a/src/resolve_mihomo_bin.rs
+++ b/src/resolve_mihomo_bin.rs
@@ -1,8 +1,10 @@
 use crate::config::{Config, MihomoChannel};
+use crate::utils::{retry_strategy, DETAIL_PREFIX, MAX_RETRIES};
 
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use reqwest::Client;
+use tokio_retry::Retry;
 
 const STABLE_VERSION_URL: &str =
     "https://github.com/MetaCubeX/mihomo/releases/latest/download/version.txt";
@@ -10,6 +12,8 @@ const ALPHA_VERSION_URL: &str =
     "https://github.com/MetaCubeX/mihomo/releases/download/Prerelease-Alpha/version.txt";
 
 /// Fetches the latest Mihomo version from GitHub based on the release channel.
+///
+/// Retries up to 3 attempts total with exponential backoff on any failure.
 pub async fn fetch_latest_version(
     client: &Client,
     channel: &MihomoChannel,
@@ -20,6 +24,26 @@ pub async fn fetch_latest_version(
         MihomoChannel::Alpha => ALPHA_VERSION_URL,
     };
 
+    let mut attempt = 0usize;
+    Retry::spawn(retry_strategy(), || {
+        let retry_no = attempt;
+        attempt += 1;
+        async move {
+            if retry_no > 0 {
+                println!(
+                    "{} Retrying version fetch (attempt {}/{})...",
+                    DETAIL_PREFIX.yellow(),
+                    retry_no,
+                    MAX_RETRIES
+                );
+            }
+            fetch_latest_version_once(client, url, user_agent).await
+        }
+    })
+    .await
+}
+
+async fn fetch_latest_version_once(client: &Client, url: &str, user_agent: &str) -> Result<String> {
     let response = client
         .get(url)
         .header("User-Agent", user_agent)

--- a/src/systemctl.rs
+++ b/src/systemctl.rs
@@ -59,4 +59,28 @@ impl Systemctl {
             .wait()
             .with_context(|| "failed to execute systemctl")
     }
+
+    /// Returns `true` if the given user service is currently active.
+    pub fn is_active(service: &str) -> bool {
+        Command::new("systemctl")
+            .arg("--user")
+            .arg("is-active")
+            .arg("--quiet")
+            .arg(service)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the given user service is enabled for autostart.
+    pub fn is_enabled(service: &str) -> bool {
+        Command::new("systemctl")
+            .arg("--user")
+            .arg("is-enabled")
+            .arg("--quiet")
+            .arg(service)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -110,7 +110,7 @@ pub async fn install_ui(
     ui: &Ui,
     target_dir: &Path,
     user_agent: &str,
-    prefix: &str,
+    prefix: impl std::fmt::Display,
 ) -> Result<()> {
     let archive_file = NamedTempFile::new()?;
     download_file(client, ui.download_url(), archive_file.path(), user_agent).await?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{self, File},
     io::{self, BufWriter, Read, Seek, SeekFrom, Write},
     path::Path,
+    time::Duration,
 };
 
 use anyhow::{Context, Result};
@@ -12,7 +13,30 @@ use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    Retry,
+};
 use truncatable::Truncatable;
+
+/// Total number of retries attempted on top of the initial request.
+pub const MAX_RETRIES: usize = 3;
+pub const DETAIL_PREFIX: &str = "   ";
+
+/// Shared retry strategy for HTTP operations.
+///
+/// Yields up to [`MAX_RETRIES`] retries (so up to `MAX_RETRIES + 1` total attempts) with
+/// exponential backoff of ~1s, ~2s, ~4s, each with jitter and capped at 5s.
+/// `ExponentialBackoff::from_millis(2).factor(500)` seeds `current = 2` and multiplies by
+/// `base = 2` each step, so the yielded delays are `2 * 500`, `4 * 500`, `8 * 500`, ... ms
+/// before jitter.
+pub fn retry_strategy() -> impl Iterator<Item = Duration> {
+    ExponentialBackoff::from_millis(2)
+        .factor(500)
+        .max_delay(Duration::from_secs(5))
+        .map(jitter)
+        .take(MAX_RETRIES)
+}
 
 /// Creates the parent directory for a given path if it does not exist.
 ///
@@ -32,8 +56,40 @@ pub fn create_parent_dir(path: &Path) -> Result<()> {
 
 /// Download file from url to path with a reusable http client.
 ///
+/// Performs the initial request, then retries up to [`MAX_RETRIES`] more times on any
+/// failure (connection, HTTP status, stream, or IO error). Each attempt truncates the
+/// destination file.
+pub async fn download_file(
+    client: &Client,
+    url: &str,
+    path: &Path,
+    user_agent: &str,
+) -> Result<()> {
+    let mut attempt = 0usize;
+    Retry::spawn(retry_strategy(), || {
+        // attempt = 0 is the initial request; retries are 1..=MAX_RETRIES.
+        let retry_no = attempt;
+        attempt += 1;
+        async move {
+            if retry_no > 0 {
+                println!(
+                    "{} Retrying download (attempt {}/{})...",
+                    DETAIL_PREFIX.yellow(),
+                    retry_no,
+                    MAX_RETRIES
+                );
+            }
+            download_file_once(client, url, path, user_agent).await
+        }
+    })
+    .await
+}
+
+/// Single-shot download with progress bar. Called by [`download_file`] on each retry.
+///
 /// Renders a progress bar if content-length is available from the url headers provided. If not,
-/// renders a spinner to indicate that something is downloading.
+/// renders a spinner to indicate that something is downloading. On failure the bar is cleared so
+/// the next retry renders cleanly.
 ///
 /// With reference from:
 /// * https://github.com/mihaigalos/tutorials/blob/800d5acbc333fd4068622e9b3d870cb5b7d34e12/rust/download_with_progressbar/src/main.rs
@@ -41,7 +97,7 @@ pub fn create_parent_dir(path: &Path) -> Result<()> {
 ///
 /// Note: Allow `clippy::unused_io_amount` because we are writing downloaded chunks on the fly.
 #[allow(clippy::unused_io_amount)]
-pub async fn download_file(
+async fn download_file_once(
     client: &Client,
     url: &str,
     path: &Path,
@@ -64,13 +120,13 @@ pub async fn download_file(
     let pb = ProgressBar::new(total_size);
 
     let bar_style = ProgressStyle::with_template(
-        "{prefix:.blue}: {msg}\n          {elapsed_precise} [{bar:30.white/blue}] \
-         {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+        "{prefix:.cyan} Downloading {msg}\n{prefix:.cyan} {elapsed_precise} \
+         [{bar:30.white/cyan}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
     )?
-    .progress_chars("-  ");
+    .progress_chars("=> ");
     let spinner_style = ProgressStyle::with_template(
-        "{prefix:.blue}: {wide_msg}\n        \
-         {spinner} {elapsed_precise} - Download speed {bytes_per_sec}",
+        "{prefix:.cyan} Downloading {wide_msg}\n{prefix:.cyan} \
+         {spinner} {elapsed_precise} \u{2014} {bytes_per_sec}",
     )?;
 
     if total_size == 0 {
@@ -78,51 +134,67 @@ pub async fn download_file(
     } else {
         pb.set_style(bar_style);
     }
-    pb.set_prefix("download");
+    pb.set_prefix(DETAIL_PREFIX);
 
     let truncated_url = Truncatable::from(url)
         .truncator("...".into())
         .truncate(64)
         .underline();
-    pb.set_message(format!("Downloading {truncated_url}"));
+    pb.set_message(format!("{truncated_url}"));
 
-    // Start file download and update progress bar when new data chunk is received
-    let mut file = File::create(path)?;
-    let mut downloaded: u64 = 0;
-    let mut stream = res.bytes_stream();
+    // Perform the streamed write in a scoped async block so we can clean up the progress bar
+    // regardless of success or failure.
+    let result: Result<()> = async {
+        let mut file = File::create(path)?;
+        let mut downloaded: u64 = 0;
+        let mut stream = res.bytes_stream();
 
-    while let Some(item) = stream.next().await {
-        let chunk = item.with_context(|| "error while downloading file")?;
+        while let Some(item) = stream.next().await {
+            let chunk = item.with_context(|| "error while downloading file")?;
 
-        file.write(&chunk)
-            .with_context(|| "error while writing to file")?;
-        if total_size != 0 {
-            let new = min(downloaded + (chunk.len() as u64), total_size);
-            downloaded = new;
-            pb.set_position(new);
-        } else {
-            pb.inc(chunk.len() as u64);
+            file.write(&chunk)
+                .with_context(|| "error while writing to file")?;
+            if total_size != 0 {
+                let new = min(downloaded + (chunk.len() as u64), total_size);
+                downloaded = new;
+                pb.set_position(new);
+            } else {
+                pb.inc(chunk.len() as u64);
+            }
         }
+        Ok(())
+    }
+    .await;
+
+    match &result {
+        Ok(()) => {
+            // Clear the progress bar and print a single summary line so the output
+            // stays visually aligned inside the stage body output.
+            pb.finish_and_clear();
+            println!(
+                "{} Downloaded to {}",
+                DETAIL_PREFIX.cyan(),
+                path.to_str().unwrap_or("").underline()
+            );
+        }
+        // Clear the bar before the outer retry loop prints its next message.
+        Err(_) => pb.finish_and_clear(),
     }
 
-    pb.finish_with_message(format!(
-        "Downloaded to {}",
-        path.to_str().unwrap().underline()
-    ));
-    Ok(())
+    result
 }
 
-pub fn delete_file(path: &str, prefix: &str) -> Result<()> {
+pub fn delete_file(path: &str, prefix: impl std::fmt::Display) -> Result<()> {
     // Delete file if exists
     if Path::new(path).exists() {
         fs::remove_file(path).map(|_| {
-            println!("{} Removed {}", prefix.cyan(), path.underline().yellow());
+            println!("{} Removed {}", prefix, path.underline().yellow());
         })?;
     }
     Ok(())
 }
 
-pub fn extract_gzip(from_path: &Path, to_path: &str, prefix: &str) -> Result<()> {
+pub fn extract_gzip(from_path: &Path, to_path: &str, prefix: impl std::fmt::Display) -> Result<()> {
     // Create parent directory for extraction dest if not exists
     create_parent_dir(Path::new(to_path))?;
 
@@ -131,11 +203,7 @@ pub fn extract_gzip(from_path: &Path, to_path: &str, prefix: &str) -> Result<()>
     let mut file = File::create(to_path)?;
     io::copy(&mut archive, &mut file)?;
     // fs::remove_file(gzip_path)?;
-    println!(
-        "{} Extracted to {}",
-        prefix.green(),
-        to_path.underline().yellow()
-    );
+    println!("{} Extracted to {}", prefix, to_path.underline().yellow());
     Ok(())
 }
 


### PR DESCRIPTION
### Description

Introduce the `mihoro init` command to streamline the setup process, replacing the deprecated `setup` command. This command features stage-based reporting, idempotent setup stages, and HTTP retry logic to enhance reliability during artifact downloads.

