### PR TITLE
Add GitHub download mirror support via MIHORO_GITHUB_MIRROR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihoro"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mihoro"
 description = "Mihomo CLI client on Linux."
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -49,13 +49,21 @@ mihoro init
 
 If `~/.config/mihoro.toml` does not exist yet, `mihoro init` will create it, prompt for your remote `mihomo` or `clash` subscription URL, save it, then finish the full onboarding flow in the same run.
 
-That single command will:
+Upon onboarding, `mihoro` will:
 
 - download the `mihomo` core binary
 - download your remote config and apply local overrides
 - download geodata and the default web dashboard
 - install and enable `mihomo.service`
 - start the service and print the local dashboard URL
+
+You can also proxy GitHub-hosted runtime downloads by setting `MIHORO_GITHUB_MIRROR` before commands such as `mihoro init` or `mihoro update`:
+
+```shell
+MIHORO_GITHUB_MIRROR=https://gh-proxy.org mihoro init
+```
+
+Note that this only applies to GitHub-hosted resource downloads and does not affect `mihoro upgrade` yet.
 
 The generated config uses sensible defaults, including `metacubexd` as the managed dashboard:
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -177,7 +177,7 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
     // https_proxy=http://127.0.0.1:<port>).  The actual service stop + binary
     // swap is deferred to the "install binary" stage after all downloads finish.
 
-    report.begin("mihomo binary", Some("downloading the mihomo binary"));
+    report.begin("mihomo binary", Some("downloading mihomo binary"));
     let binary_temp = match mihoro.prepare_binary(client, force, arch).await {
         Ok(BinaryPlan::Install(temp)) => {
             report.record("mihomo binary", StageStatus::Installed);

--- a/src/init.rs
+++ b/src/init.rs
@@ -177,10 +177,7 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
     // https_proxy=http://127.0.0.1:<port>).  The actual service stop + binary
     // swap is deferred to the "install binary" stage after all downloads finish.
 
-    report.begin(
-        "mihomo binary",
-        Some("Resolve the target build and download the mihomo release archive"),
-    );
+    report.begin("mihomo binary", Some("downloading the mihomo binary"));
     let binary_temp = match mihoro.prepare_binary(client, force, arch).await {
         Ok(BinaryPlan::Install(temp)) => {
             report.record("mihomo binary", StageStatus::Installed);
@@ -199,21 +196,19 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
     report
         .run(
             "remote config",
-            Some("Download the remote config and apply local mihoro.toml overrides"),
+            Some("downloading and merging remote config"),
             || mihoro.ensure_remote_config(client, force),
         )
         .await;
     report
-        .run(
-            "geodata",
-            Some("Download geoip / geosite data files required by mihomo"),
-            || mihoro.ensure_geodata(client, force),
-        )
+        .run("geodata", Some("downloading geodata"), || {
+            mihoro.ensure_geodata(client, force)
+        })
         .await;
     report
         .run(
             "web dashboard",
-            Some("Download and install the configured web UI assets"),
+            Some("downloading dashboard assets"),
             || mihoro.ensure_ui(client, force),
         )
         .await;
@@ -223,8 +218,8 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
     // All network calls are done.  Now it is safe to stop the running service
     // (which also tears down the proxy) and swap in the new binary.
     //
-    // If the remote config stage failed we must not proceed: installing a new
-    // binary or restarting the service on top of a missing / corrupt config.yaml
+    // If remote config stage failed we must not proceed: installing a new
+    // binary or restarting mihomo.service on top of a missing / corrupt config.yaml
     // would break an environment that may have been working before.
 
     if report.stage_failed("remote config") {
@@ -233,10 +228,7 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
         report.record("systemd service", skip());
         report.record("service start", skip());
     } else {
-        report.begin(
-            "install binary",
-            Some("Install the downloaded mihomo binary into the configured path"),
-        );
+        report.begin("install binary", Some("installing mihomo binary"));
         let install_status = match binary_temp {
             None => StageStatus::Skipped("nothing to install".to_string()),
             Some(temp) => match mihoro.install_binary(temp).await {
@@ -247,14 +239,18 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
         report.record("install binary", install_status);
 
         report
-            .run("systemd service", None, || async {
-                mihoro.ensure_service().await
-            })
+            .run(
+                "systemd service",
+                Some("writing systemd service"),
+                || async { mihoro.ensure_service().await },
+            )
             .await;
         report
-            .run("service start", None, || async {
-                mihoro.ensure_service_running().await
-            })
+            .run(
+                "service start",
+                Some("starting and enabling mihomo.service"),
+                || async { mihoro.ensure_service_running().await },
+            )
             .await;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,41 +144,35 @@ async fn cli() -> Result<()> {
             arch,
             ui,
         }) => {
-            println!("{} update", "mihoro:".cyan().bold());
+            println!("{} update initiated", "mihoro:".cyan().bold());
             let mut report = StageReport::new();
 
             if *all {
                 report
-                    .run(
-                        "config",
-                        Some("Download the remote config and apply local overrides"),
-                        || mihoro.update_config(&client),
-                    )
+                    .run("config", Some("refreshing remote config"), || {
+                        mihoro.update_config(&client)
+                    })
                     .await;
                 report
-                    .run(
-                        "geodata",
-                        Some("Refresh geoip / geosite data used by mihomo"),
-                        || mihoro.update_geodata(&client),
-                    )
+                    .run("geodata", Some("refreshing geodata"), || {
+                        mihoro.update_geodata(&client)
+                    })
                     .await;
                 report
-                    .run(
-                        "ui",
-                        Some("Download and install the configured web dashboard"),
-                        || mihoro.update_ui(&client),
-                    )
+                    .run("ui", Some("refreshing dashboard assets"), || {
+                        mihoro.update_ui(&client)
+                    })
                     .await;
                 report
-                    .run(
-                        "core",
-                        Some("Download and install the latest mihomo core binary"),
-                        || mihoro.update_core(&client, arch.as_deref()),
-                    )
+                    .run("core", Some("refreshing mihomo core"), || {
+                        mihoro.update_core(&client, arch.as_deref())
+                    })
                     .await;
                 if !report.has_failures() {
                     report
-                        .run("service restart", None, || mihoro.restart_service())
+                        .run("service restart", Some("restarting mihomo.service"), || {
+                            mihoro.restart_service()
+                        })
                         .await;
                 } else {
                     report.record(
@@ -188,15 +182,15 @@ async fn cli() -> Result<()> {
                 }
             } else if *core {
                 report
-                    .run(
-                        "core",
-                        Some("Download and install the latest mihomo core binary"),
-                        || mihoro.update_core(&client, arch.as_deref()),
-                    )
+                    .run("core", Some("refreshing mihomo core"), || {
+                        mihoro.update_core(&client, arch.as_deref())
+                    })
                     .await;
                 if !report.has_failures() {
                     report
-                        .run("service restart", None, || mihoro.restart_service())
+                        .run("service restart", Some("restarting mihomo.service"), || {
+                            mihoro.restart_service()
+                        })
                         .await;
                 } else {
                     report.record(
@@ -206,31 +200,27 @@ async fn cli() -> Result<()> {
                 }
             } else if *ui {
                 report
-                    .run(
-                        "ui",
-                        Some("Download and install the configured web dashboard"),
-                        || mihoro.update_ui(&client),
-                    )
+                    .run("ui", Some("refreshing dashboard assets"), || {
+                        mihoro.update_ui(&client)
+                    })
                     .await;
             } else if *geodata {
                 report
-                    .run(
-                        "geodata",
-                        Some("Refresh geoip / geosite data used by mihomo"),
-                        || mihoro.update_geodata(&client),
-                    )
+                    .run("geodata", Some("refreshing geodata"), || {
+                        mihoro.update_geodata(&client)
+                    })
                     .await;
             } else if *config || (!*core && !*geodata && !*ui) {
                 report
-                    .run(
-                        "config",
-                        Some("Download the remote config and apply local overrides"),
-                        || mihoro.update_config(&client),
-                    )
+                    .run("config", Some("refreshing remote config"), || {
+                        mihoro.update_config(&client)
+                    })
                     .await;
                 if !report.has_failures() {
                     report
-                        .run("service restart", None, || mihoro.restart_service())
+                        .run("service restart", Some("restarting mihomo.service"), || {
+                            mihoro.restart_service()
+                        })
                         .await;
                 } else {
                     report.record(

--- a/src/mihoro.rs
+++ b/src/mihoro.rs
@@ -541,7 +541,7 @@ impl Mihoro {
     }
 }
 
-/// Render the systemd unit file content for the mihomo service.
+/// Render the systemd unit file content for mihomo.service.
 ///
 /// Reference: https://wiki.metacubex.one/startup/service/
 fn render_service_string(binary_path: &str, config_root: &str) -> String {

--- a/src/mihoro.rs
+++ b/src/mihoro.rs
@@ -122,7 +122,7 @@ impl Mihoro {
     ///
     /// Must run *after* every other network-dependent stage; see [`BinaryPlan`].
     pub async fn install_binary(&self, temp_file: NamedTempFile) -> Result<StageStatus> {
-        // Stop the service before overwriting to avoid "Text file busy".
+        // Stop mihomo.service before overwriting to avoid "Text file busy".
         let binary_exists = fs::metadata(&self.mihomo_target_binary_path).is_ok();
         if binary_exists {
             println!(
@@ -264,7 +264,7 @@ impl Mihoro {
 
     /// Enable and start mihomo.service, ensuring both autostart and current-session state.
     ///
-    /// Always enables the service so it survives reboots, even if it was already running but
+    /// Always enables mihomo.service so it survives reboots, even if it was already running but
     /// not enabled (e.g. started manually after a previous failed init).
     pub async fn ensure_service_running(&self) -> Result<StageStatus> {
         let is_active = Systemctl::is_active("mihomo.service");
@@ -321,7 +321,7 @@ impl Mihoro {
         )
         .await?;
 
-        // Stop the service before overwriting binary to avoid "Text file busy" error
+        // Stop mihomo.service before overwriting binary to avoid "Text file busy" error
         println!(
             "{} Stopping mihomo.service before overwriting...",
             DETAIL_PREFIX.yellow()

--- a/src/resolve_mihomo_bin.rs
+++ b/src/resolve_mihomo_bin.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, MihomoChannel};
-use crate::utils::{retry_strategy, DETAIL_PREFIX, MAX_RETRIES};
+use crate::utils::{resolve_download_url, retry_strategy, DETAIL_PREFIX, MAX_RETRIES};
 
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
@@ -44,12 +44,13 @@ pub async fn fetch_latest_version(
 }
 
 async fn fetch_latest_version_once(client: &Client, url: &str, user_agent: &str) -> Result<String> {
+    let resolved_url = resolve_download_url(url);
     let response = client
-        .get(url)
+        .get(resolved_url.as_ref())
         .header("User-Agent", user_agent)
         .send()
         .await
-        .with_context(|| format!("failed to fetch version from '{}'", url))?;
+        .with_context(|| format!("failed to fetch version from '{}'", resolved_url.as_ref()))?;
 
     response.error_for_status_ref()?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     cmp::min,
     fs::{self, File},
     io::{self, BufWriter, Read, Seek, SeekFrom, Write},
@@ -22,6 +23,7 @@ use truncatable::Truncatable;
 /// Total number of retries attempted on top of the initial request.
 pub const MAX_RETRIES: usize = 3;
 pub const DETAIL_PREFIX: &str = "   ";
+pub const MIHORO_GITHUB_MIRROR_ENV: &str = "MIHORO_GITHUB_MIRROR";
 
 /// Shared retry strategy for HTTP operations.
 ///
@@ -52,6 +54,47 @@ pub fn create_parent_dir(path: &Path) -> Result<()> {
         fs::create_dir_all(parent_dir)?;
     }
     Ok(())
+}
+
+fn github_mirror_base() -> Option<String> {
+    let mirror = std::env::var(MIHORO_GITHUB_MIRROR_ENV).ok()?;
+    let mirror = mirror.trim().trim_end_matches('/').to_string();
+    if mirror.is_empty() {
+        return None;
+    }
+    Some(mirror)
+}
+
+fn is_github_download_host(host: &str) -> bool {
+    host == "github.com" || host.ends_with(".githubusercontent.com")
+}
+
+/// Prefix GitHub-hosted download urls with the configured mirror, if any.
+///
+/// This intentionally excludes `api.github.com` so API metadata requests continue to use
+/// GitHub directly while large artifact downloads can still flow through a mirror.
+pub fn resolve_download_url(url: &str) -> Cow<'_, str> {
+    let Some(mirror) = github_mirror_base() else {
+        return Cow::Borrowed(url);
+    };
+
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return Cow::Borrowed(url);
+    };
+
+    let Some(host) = parsed.host_str() else {
+        return Cow::Borrowed(url);
+    };
+
+    if !is_github_download_host(host) {
+        return Cow::Borrowed(url);
+    }
+
+    if url == mirror || url.starts_with(&format!("{mirror}/")) {
+        return Cow::Borrowed(url);
+    }
+
+    Cow::Owned(format!("{mirror}/{url}"))
 }
 
 /// Download file from url to path with a reusable http client.
@@ -103,16 +146,18 @@ async fn download_file_once(
     path: &Path,
     user_agent: &str,
 ) -> Result<()> {
+    let resolved_url = resolve_download_url(url);
+
     // Create parent directory for download destination if not exists
     create_parent_dir(path)?;
 
     // Create shared http client for multiple downloads when possible
     let res = client
-        .get(url)
+        .get(resolved_url.as_ref())
         .header("User-Agent", user_agent)
         .send()
         .await
-        .with_context(|| format!("failed to GET from '{}'", &url))?;
+        .with_context(|| format!("failed to GET from '{}'", resolved_url.as_ref()))?;
     res.error_for_status_ref()?;
 
     // If content length is not available or 0, use a spinner instead of a progress bar
@@ -123,7 +168,7 @@ async fn download_file_once(
         "{prefix:.cyan} Downloading {msg}\n{prefix:.cyan} {elapsed_precise} \
          [{bar:30.white/cyan}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
     )?
-    .progress_chars("=> ");
+    .progress_chars("-> ");
     let spinner_style = ProgressStyle::with_template(
         "{prefix:.cyan} Downloading {wide_msg}\n{prefix:.cyan} \
          {spinner} {elapsed_precise} \u{2014} {bytes_per_sec}",
@@ -246,8 +291,16 @@ pub fn try_decode_base64_file_inplace(filepath: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::{
+        fs,
+        sync::{Mutex, OnceLock},
+    };
     use tempfile::tempdir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn test_create_parent_dir_creates_directories() -> Result<()> {
@@ -340,5 +393,39 @@ mod tests {
         assert_eq!(content, "not valid base64!!!");
 
         Ok(())
+    }
+
+    #[test]
+    fn test_resolve_download_url_uses_mirror_for_github_downloads() {
+        let _guard = env_lock().lock().unwrap();
+        std::env::set_var(MIHORO_GITHUB_MIRROR_ENV, "https://gh-proxy.org/");
+
+        let resolved = resolve_download_url(
+            "https://github.com/MetaCubeX/mihomo/releases/latest/download/version.txt",
+        );
+        assert_eq!(
+            resolved.as_ref(),
+            "https://gh-proxy.org/https://github.com/MetaCubeX/mihomo/releases/latest/download/version.txt"
+        );
+
+        std::env::remove_var(MIHORO_GITHUB_MIRROR_ENV);
+    }
+
+    #[test]
+    fn test_resolve_download_url_keeps_non_github_urls_and_api_urls() {
+        let _guard = env_lock().lock().unwrap();
+        std::env::set_var(MIHORO_GITHUB_MIRROR_ENV, "https://gh-proxy.org");
+
+        assert_eq!(
+            resolve_download_url("https://example.com/file.tar.gz").as_ref(),
+            "https://example.com/file.tar.gz"
+        );
+        assert_eq!(
+            resolve_download_url("https://api.github.com/repos/spencerwooo/mihoro/releases/latest")
+                .as_ref(),
+            "https://api.github.com/repos/spencerwooo/mihoro/releases/latest"
+        );
+
+        std::env::remove_var(MIHORO_GITHUB_MIRROR_ENV);
     }
 }


### PR DESCRIPTION
### Description

Introduce support for a GitHub download mirror by allowing users to set the `MIHORO_GITHUB_MIRROR` environment variable. This enables the redirection of GitHub-hosted downloads through a specified mirror.

This does not support `mihoro upgrade` that upgrades `mihoro` itself, as it relies on accessing the GitHub API which cannot be proxied over a mirror.

### Linked Issues

- #186