### PR TITLE
fix(cron): preserve existing crontab entries on enable/disable

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-/// Get the path to the user's crontab file
+/// Get the path to the staging file used to install crontab via `crontab <file>`.
 fn crontab_path() -> PathBuf {
     let run_dir = env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| {
         // Use current user's UID as fallback
@@ -34,13 +34,80 @@ fn generate_cron_entry(interval_hours: u16) -> Result<String> {
     ))
 }
 
-/// Generate the crontab content with mihoro entry
-fn generate_crontab(interval_hours: u16) -> Result<String> {
-    let mihoro_entry = generate_cron_entry(interval_hours)?;
-    Ok(mihoro_entry)
+/// Read the current user's crontab via `crontab -l`. Returns an empty string
+/// when no crontab exists or the command fails for any other reason — the
+/// resulting empty input is treated as "no preexisting entries".
+fn read_current_crontab() -> String {
+    Command::new("crontab")
+        .arg("-l")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+        .unwrap_or_default()
 }
 
-/// Enable auto-update by installing cron job
+/// Decide whether a crontab line was installed by mihoro and should be
+/// replaced/removed by us. Comments and blank lines are never matched so we
+/// don't accidentally drop user annotations.
+fn is_mihoro_entry(line: &str, bin_path: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return false;
+    }
+    // Primary: exact current binary path.
+    if trimmed.contains(&format!("{} update", bin_path)) {
+        return true;
+    }
+    // Fallback: any path ending in `/mihoro update`. Catches stale entries
+    // installed by a previous mihoro that lived at a different path.
+    trimmed.ends_with("/mihoro update")
+}
+
+/// Merge `new_entry` into `existing` crontab content, replacing any prior
+/// mihoro entry. Returns the new crontab body with a single trailing newline.
+fn merge_crontab(existing: &str, new_entry: &str, bin_path: &str) -> String {
+    let mut kept: Vec<String> = existing
+        .lines()
+        .filter(|l| !is_mihoro_entry(l, bin_path))
+        .map(String::from)
+        .collect();
+    kept.push(new_entry.trim_end().to_string());
+    let mut joined = kept.join("\n");
+    joined.push('\n');
+    joined
+}
+
+/// Filter out any mihoro-owned entries from `existing`. Returns `None` if no
+/// non-mihoro entries remain (caller should `crontab -r` instead of installing
+/// an empty file, which some `crontab` implementations reject).
+fn strip_mihoro_entries(existing: &str, bin_path: &str) -> Option<String> {
+    let kept: Vec<&str> = existing
+        .lines()
+        .filter(|l| !is_mihoro_entry(l, bin_path))
+        .collect();
+    if kept.is_empty() {
+        None
+    } else {
+        let mut joined = kept.join("\n");
+        joined.push('\n');
+        Some(joined)
+    }
+}
+
+/// Stage `content` to a temp file and install it via `crontab <file>`.
+fn install_crontab(content: &str) -> Result<()> {
+    let crontab_file = crontab_path();
+    fs::write(&crontab_file, content)?;
+    let status = Command::new("crontab").arg(&crontab_file).status()?;
+    if !status.success() {
+        anyhow::bail!("Failed to install crontab");
+    }
+    Ok(())
+}
+
+/// Enable auto-update by installing/refreshing the mihoro cron entry while
+/// preserving every other entry in the user's crontab.
 pub fn enable_auto_update(interval_hours: u16, prefix: &str) -> Result<()> {
     if interval_hours == 0 {
         println!(
@@ -54,62 +121,50 @@ pub fn enable_auto_update(interval_hours: u16, prefix: &str) -> Result<()> {
         anyhow::bail!("Auto-update interval must be between 1 and 24 hours");
     }
 
-    let crontab_content = generate_crontab(interval_hours)?;
-    let crontab_file = crontab_path();
+    let bin_path = mihoro_bin_path()?;
+    let new_entry = generate_cron_entry(interval_hours)?;
+    let existing = read_current_crontab();
+    let merged = merge_crontab(&existing, &new_entry, &bin_path);
 
-    // Write crontab to runtime directory for reference
-    fs::write(&crontab_file, crontab_content)?;
-
-    // Install crontab using crontab command
-    let status = std::process::Command::new("crontab")
-        .arg(&crontab_file)
-        .status()?;
-
-    if !status.success() {
-        anyhow::bail!("Failed to install crontab");
-    }
+    install_crontab(&merged)?;
 
     println!(
         "{} Auto-update enabled with interval: {} hours",
         prefix.green().bold(),
         interval_hours.to_string().yellow()
     );
-    println!(
-        "{} Cron entry: {}",
-        "->".dimmed(),
-        generate_cron_entry(interval_hours)?.trim()
-    );
+    println!("{} Cron entry: {}", "->".dimmed(), new_entry.trim());
 
     Ok(())
 }
 
-/// Disable auto-update by removing cron job
+/// Disable auto-update by removing only mihoro's cron entry. Other user
+/// entries are preserved. If mihoro was the only entry, the crontab is
+/// removed entirely with `crontab -r`.
 pub fn disable_auto_update(prefix: &str) -> Result<()> {
+    let bin_path = mihoro_bin_path()?;
+    let existing = read_current_crontab();
+
+    match strip_mihoro_entries(&existing, &bin_path) {
+        Some(remaining) => {
+            install_crontab(&remaining)?;
+        }
+        None => {
+            // No other entries — remove the crontab entirely. `crontab -r`
+            // exits non-zero when there is no crontab to remove; treat that
+            // as success rather than an error.
+            let _ = Command::new("crontab").arg("-r").status();
+        }
+    }
+
+    // Best-effort cleanup of the staging file from older mihoro versions.
     let crontab_file = crontab_path();
-
-    // Remove our crontab reference file
     if crontab_file.exists() {
-        fs::remove_file(&crontab_file)?;
+        let _ = fs::remove_file(&crontab_file);
     }
 
-    // Install empty crontab to remove all entries
-    let status = std::process::Command::new("crontab").arg("-r").status();
-
-    match status {
-        Ok(status) if status.success() => {
-            println!("{} Auto-update disabled", prefix.green().bold());
-            Ok(())
-        }
-        Ok(_) => {
-            // crontab -r returns non-zero if no crontab exists, which is fine
-            println!(
-                "{} Auto-update disabled (no active cron job)",
-                prefix.yellow()
-            );
-            Ok(())
-        }
-        Err(e) => Err(anyhow!("Failed to disable crontab: {}", e)),
-    }
+    println!("{} Auto-update disabled", prefix.green().bold());
+    Ok(())
 }
 
 /// Format Unix timestamp to local datetime string using date command
@@ -128,20 +183,23 @@ fn format_datetime(secs: u64) -> String {
     }
 }
 
-/// Get current cron status
+/// Get current cron status by inspecting the live crontab. This is robust
+/// across reboots and across manual `crontab -e` edits.
 pub fn get_cron_status(_prefix: &str, mihomo_config_path: &str) -> Result<()> {
-    let crontab_file = crontab_path();
+    let bin_path = mihoro_bin_path()?;
+    let existing = read_current_crontab();
+    let entry = existing.lines().find(|l| is_mihoro_entry(l, &bin_path));
 
-    if !crontab_file.exists() {
-        println!("{} Auto-update is disabled", "status:".yellow().bold());
-        return Ok(());
+    match entry {
+        Some(line) => {
+            println!("{} Auto-update is enabled", "status:".green().bold());
+            println!("{} {}", "->".dimmed(), line.dimmed());
+        }
+        None => {
+            println!("{} Auto-update is disabled", "status:".yellow().bold());
+            return Ok(());
+        }
     }
-
-    let content = fs::read_to_string(&crontab_file)?;
-    let cron_entry = content.lines().next().unwrap_or("");
-
-    println!("{} Auto-update is enabled", "status:".green().bold());
-    println!("{} {}", "->".dimmed(), cron_entry.dimmed());
 
     // Show last updated time from mihomo config file
     let config_path = Path::new(mihomo_config_path);
@@ -171,8 +229,90 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_crontab() {
-        let crontab = generate_crontab(6).unwrap();
-        assert!(crontab.contains("0 */6 * * *"));
+    fn test_is_mihoro_entry_matches_current_path() {
+        let bin = "/root/.local/bin/mihoro";
+        assert!(is_mihoro_entry(
+            "0 */12 * * * /root/.local/bin/mihoro update",
+            bin
+        ));
+    }
+
+    #[test]
+    fn test_is_mihoro_entry_matches_legacy_path() {
+        let bin = "/usr/local/bin/mihoro";
+        // Path differs from current binary but still ends in `/mihoro update`.
+        assert!(is_mihoro_entry(
+            "0 */6 * * * /opt/mihoro/bin/mihoro update",
+            bin
+        ));
+    }
+
+    #[test]
+    fn test_is_mihoro_entry_ignores_comments_and_blank() {
+        let bin = "/root/.local/bin/mihoro";
+        assert!(!is_mihoro_entry("", bin));
+        assert!(!is_mihoro_entry("   ", bin));
+        assert!(!is_mihoro_entry("# /root/.local/bin/mihoro update", bin));
+    }
+
+    #[test]
+    fn test_is_mihoro_entry_does_not_match_unrelated() {
+        let bin = "/root/.local/bin/mihoro";
+        assert!(!is_mihoro_entry(
+            "27 16 * * * /root/.acme.sh/acme.sh --cron --home /root/.acme.sh > /dev/null",
+            bin
+        ));
+        assert!(!is_mihoro_entry("0 3 * * * /usr/bin/mihomo --reload", bin));
+    }
+
+    #[test]
+    fn test_merge_crontab_preserves_existing() {
+        let bin = "/root/.local/bin/mihoro";
+        let existing = "\
+27 16 * * * /root/.acme.sh/acme.sh --cron > /dev/null
+0 3 * * * /opt/backup/run.sh
+";
+        let new_entry = "0 */12 * * * /root/.local/bin/mihoro update\n";
+        let merged = merge_crontab(existing, new_entry, bin);
+
+        assert!(merged.contains("/root/.acme.sh/acme.sh"));
+        assert!(merged.contains("/opt/backup/run.sh"));
+        assert!(merged.contains("/root/.local/bin/mihoro update"));
+        assert!(merged.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_merge_crontab_replaces_existing_mihoro_entry() {
+        let bin = "/root/.local/bin/mihoro";
+        let existing = "\
+0 */6 * * * /root/.local/bin/mihoro update
+27 16 * * * /root/.acme.sh/acme.sh --cron > /dev/null
+";
+        let new_entry = "0 */12 * * * /root/.local/bin/mihoro update\n";
+        let merged = merge_crontab(existing, new_entry, bin);
+
+        assert_eq!(merged.matches("/root/.local/bin/mihoro update").count(), 1);
+        assert!(merged.contains("0 */12 * * *"));
+        assert!(!merged.contains("0 */6 * * *"));
+        assert!(merged.contains("/root/.acme.sh/acme.sh"));
+    }
+
+    #[test]
+    fn test_strip_mihoro_entries_keeps_others() {
+        let bin = "/root/.local/bin/mihoro";
+        let existing = "\
+0 */12 * * * /root/.local/bin/mihoro update
+27 16 * * * /root/.acme.sh/acme.sh --cron > /dev/null
+";
+        let stripped = strip_mihoro_entries(existing, bin).expect("non-empty");
+        assert!(!stripped.contains("/root/.local/bin/mihoro update"));
+        assert!(stripped.contains("/root/.acme.sh/acme.sh"));
+    }
+
+    #[test]
+    fn test_strip_mihoro_entries_returns_none_when_only_mihoro() {
+        let bin = "/root/.local/bin/mihoro";
+        let existing = "0 */12 * * * /root/.local/bin/mihoro update\n";
+        assert!(strip_mihoro_entries(existing, bin).is_none());
     }
 }


### PR DESCRIPTION
Closes #196.

## What this fixes

`mihoro cron enable` and `mihoro cron disable` both silently destroy unrelated cron jobs that happen to live in the same user's crontab (acme.sh renewals, backup scripts, panel software, etc). This PR makes both commands additive.

## Behavior change

| Command  | Before                                                                  | After                                                                                                            |
| -------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
| `enable` | Installs a crontab containing **only** the mihoro line — wipes the rest | Reads live crontab via `crontab -l`, drops any prior mihoro entry, appends the new entry, installs the merge     |
| `disable`| Runs `crontab -r` — removes the **entire** crontab                      | Reads live crontab, drops only the mihoro entry, reinstalls. Falls back to `crontab -r` only if nothing remains  |
| `status` | Inferred from a staging file in `$XDG_RUNTIME_DIR` (lies after reboot)  | Inspects the live crontab directly                                                                               |

## Implementation notes

- New helpers in `src/cron.rs`:
  - `read_current_crontab()` — runs `crontab -l`, treats failure as empty
  - `is_mihoro_entry(line, bin_path)` — matches both the current binary path and any legacy `…/mihoro update` entry, so a moved/renamed install doesn't leave duplicates
  - `merge_crontab(existing, new_entry, bin_path)` — pure function for `enable`
  - `strip_mihoro_entries(existing, bin_path) -> Option<String>` — pure function for `disable`, returns `None` when nothing else remains
  - `install_crontab(content)` — stages content in `$XDG_RUNTIME_DIR/mihoro-crontab` and runs `crontab <file>`
- The previous `generate_crontab(interval_hours)` wrapper became redundant and is removed.
- `get_cron_status` now sources from the live crontab so a reboot or manual `crontab -e` doesn't make it report incorrectly.

## Tests

Added 8 new unit tests and kept the existing one — pure-function tests, no system mutation:

```
test cron::tests::test_generate_cron_entry ... ok
test cron::tests::test_is_mihoro_entry_matches_current_path ... ok
test cron::tests::test_is_mihoro_entry_matches_legacy_path ... ok
test cron::tests::test_is_mihoro_entry_ignores_comments_and_blank ... ok
test cron::tests::test_is_mihoro_entry_does_not_match_unrelated ... ok
test cron::tests::test_merge_crontab_preserves_existing ... ok
test cron::tests::test_merge_crontab_replaces_existing_mihoro_entry ... ok
test cron::tests::test_strip_mihoro_entries_keeps_others ... ok
test cron::tests::test_strip_mihoro_entries_returns_none_when_only_mihoro ... ok
```

`cargo test`, `cargo build`, `cargo fmt --check`, and `cargo clippy` (on `cron.rs`) all pass.

## Manual verification

Reproduced the original bug on the system that triggered #196 (Debian 12, mihoro 0.14.0): `mihoro cron enable` wiped pre-existing `acme.sh` and BT panel cron entries. With this patch, those entries survive both `enable` and `disable`, and `status` correctly reflects the live crontab.