### PR TITLE
feat: add system-level service option and update related logic

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -31,6 +31,10 @@ pub enum Commands {
         /// ppc64le, riscv64, s390x
         #[arg(long)]
         arch: Option<String>,
+
+        /// Install as system-level service (requires root, default: user-level)
+        #[arg(long)]
+        system: bool,
     },
     /// Deprecated: use `mihoro init` instead
     #[command(hide = true)]

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,6 +14,7 @@ pub struct InitOptions {
     pub force: bool,
     pub arch: Option<String>,
     pub yes: bool,
+    pub system: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -303,7 +304,16 @@ pub async fn run(config_path: &str, client: &Client, opts: InitOptions) -> Resul
     let config = bootstrap_config(config_path, opts.yes)?;
     validate_config(&config)?;
 
-    let mihoro = Mihoro::from_config(config.clone());
+    // Fail early before any downloads if we can't write to the system service directory
+    if opts.system && std::fs::write("/etc/systemd/system/.mihoro_test", b"").is_err() {
+        bail!(
+            "--system requires root privileges\n       Try: {}",
+            "sudo mihoro init --system".bold()
+        );
+    }
+    let _ = std::fs::remove_file("/etc/systemd/system/.mihoro_test");
+
+    let mihoro = Mihoro::from_config(config.clone(), opts.system);
 
     println!("{} initializing", "mihoro:".cyan().bold());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use std::{future::Future, io, process::Command, time::Duration};
 
 use cmd::{Args, ClapShell, Commands};
 use mihoro::{Mihoro, StageStatus};
-use systemctl::Systemctl;
+use systemctl::{Systemctl, SystemdScope};
 
 struct StageReport {
     entries: Vec<(&'static str, StageStatus)>,
@@ -107,7 +107,12 @@ async fn cli() -> Result<()> {
 
     // Handle Init and Setup before constructing Mihoro, which requires a valid config.
     match &args.command {
-        Some(Commands::Init { force, arch, yes }) => {
+        Some(Commands::Init {
+            force,
+            arch,
+            yes,
+            system,
+        }) => {
             return init::run(
                 &args.mihoro_config,
                 &client,
@@ -115,6 +120,7 @@ async fn cli() -> Result<()> {
                     force: *force,
                     arch: arch.clone(),
                     yes: *yes,
+                    system: *system,
                 },
             )
             .await;
@@ -131,6 +137,7 @@ async fn cli() -> Result<()> {
                     force: *overwrite,
                     arch: arch.clone(),
                     yes: true,
+                    system: false,
                 },
             )
             .await;
@@ -250,7 +257,7 @@ async fn cli() -> Result<()> {
         Some(Commands::Uninstall) => mihoro.uninstall()?,
         Some(Commands::Proxy { proxy }) => mihoro.proxy_commands(proxy)?,
 
-        Some(Commands::Start) => Systemctl::new()
+        Some(Commands::Start) => Systemctl::with_scope(mihoro.systemd_scope)
             .start("mihomo.service")
             .execute()
             .map(|_| {
@@ -258,26 +265,31 @@ async fn cli() -> Result<()> {
             })?,
 
         Some(Commands::Status) => {
-            Systemctl::new().status("mihomo.service").execute()?;
+            Systemctl::with_scope(mihoro.systemd_scope)
+                .status("mihomo.service")
+                .execute()?;
         }
 
-        Some(Commands::Stop) => Systemctl::new().stop("mihomo.service").execute().map(|_| {
-            println!("{} Stopped mihomo.service", mihoro.prefix.green());
-        })?,
+        Some(Commands::Stop) => Systemctl::with_scope(mihoro.systemd_scope)
+            .stop("mihomo.service")
+            .execute()
+            .map(|_| {
+                println!("{} Stopped mihomo.service", mihoro.prefix.green());
+            })?,
 
-        Some(Commands::Restart) => {
-            Systemctl::new()
-                .restart("mihomo.service")
-                .execute()
-                .map(|_| {
-                    println!("{} Restarted mihomo.service", mihoro.prefix.green());
-                })?
-        }
+        Some(Commands::Restart) => Systemctl::with_scope(mihoro.systemd_scope)
+            .restart("mihomo.service")
+            .execute()
+            .map(|_| {
+                println!("{} Restarted mihomo.service", mihoro.prefix.green());
+            })?,
 
         Some(Commands::Log) => {
-            Command::new("journalctl")
-                .arg("--user")
-                .arg("-xeu")
+            let mut cmd = Command::new("journalctl");
+            if matches!(mihoro.systemd_scope, SystemdScope::User) {
+                cmd.arg("--user");
+            }
+            cmd.arg("-xeu")
                 .arg("mihomo.service")
                 .arg("-n")
                 .arg("10")

--- a/src/mihoro.rs
+++ b/src/mihoro.rs
@@ -3,7 +3,7 @@ use crate::config::{apply_mihomo_override, parse_config, Config};
 use crate::cron;
 use crate::proxy::{proxy_export_cmd, proxy_unset_cmd};
 use crate::resolve_mihomo_bin;
-use crate::systemctl::Systemctl;
+use crate::systemctl::{Systemctl, SystemdScope};
 use crate::ui::{install_ui, resolve_external_ui_path};
 use crate::utils::{
     create_parent_dir, delete_file, download_file, extract_gzip, try_decode_base64_file_inplace,
@@ -35,6 +35,7 @@ pub struct Mihoro {
     pub mihomo_target_config_root: String,
     pub mihomo_target_config_path: String,
     pub mihomo_target_service_path: String,
+    pub systemd_scope: SystemdScope,
 }
 
 /// Outcome of a single setup stage, used by `mihoro init`.
@@ -60,22 +61,30 @@ pub enum BinaryPlan {
 impl Mihoro {
     pub fn new(config_path: &str) -> Result<Mihoro> {
         let config = parse_config(tilde(config_path).as_ref())?;
-        Ok(Self::from_config(config))
+        // Auto-detect: system-level service file exists → system scope
+        let system = Path::new("/etc/systemd/system/mihomo.service").exists();
+        Ok(Self::from_config(config, system))
     }
 
     /// Build a `Mihoro` from an already-validated `Config`.
-    pub fn from_config(config: Config) -> Mihoro {
+    pub fn from_config(config: Config, system: bool) -> Mihoro {
+        let scope = if system {
+            SystemdScope::System
+        } else {
+            SystemdScope::User
+        };
+        let service_root = match scope {
+            SystemdScope::User => tilde(&config.user_systemd_root).to_string(),
+            SystemdScope::System => "/etc/systemd/system".to_string(),
+        };
         Mihoro {
             prefix: String::from("mihoro:"),
             mihomo_target_binary_path: tilde(&config.mihomo_binary_path).to_string(),
             mihomo_target_config_root: tilde(&config.mihomo_config_root).to_string(),
             mihomo_target_config_path: tilde(&format!("{}/config.yaml", config.mihomo_config_root))
                 .to_string(),
-            mihomo_target_service_path: tilde(&format!(
-                "{}/mihomo.service",
-                config.user_systemd_root
-            ))
-            .to_string(),
+            mihomo_target_service_path: format!("{}/mihomo.service", service_root),
+            systemd_scope: scope,
             config,
         }
     }
@@ -130,7 +139,9 @@ impl Mihoro {
                 "{} Stopping mihomo.service before overwriting binary...",
                 DETAIL_PREFIX.cyan()
             );
-            Systemctl::new().stop("mihomo.service").execute()?;
+            Systemctl::with_scope(self.systemd_scope)
+                .stop("mihomo.service")
+                .execute()?;
         }
 
         extract_gzip(
@@ -251,6 +262,7 @@ impl Mihoro {
         let service_content = render_service_string(
             &self.mihomo_target_binary_path,
             &self.mihomo_target_config_root,
+            self.systemd_scope,
         );
         if let Ok(existing) = fs::read_to_string(&self.mihomo_target_service_path) {
             if existing == service_content {
@@ -259,7 +271,9 @@ impl Mihoro {
         }
         create_parent_dir(Path::new(&self.mihomo_target_service_path))?;
         fs::write(&self.mihomo_target_service_path, &service_content)?;
-        Systemctl::new().daemon_reload().execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .daemon_reload()
+            .execute()?;
         println!(
             "{} Created mihomo.service at {}",
             DETAIL_PREFIX.cyan(),
@@ -273,8 +287,8 @@ impl Mihoro {
     /// Always enables mihomo.service so it survives reboots, even if it was already running but
     /// not enabled (e.g. started manually after a previous failed init).
     pub async fn ensure_service_running(&self) -> Result<StageStatus> {
-        let is_active = Systemctl::is_active("mihomo.service");
-        let is_enabled = Systemctl::is_enabled("mihomo.service");
+        let is_active = Systemctl::with_scope(self.systemd_scope).is_active("mihomo.service");
+        let is_enabled = Systemctl::with_scope(self.systemd_scope).is_enabled("mihomo.service");
 
         if is_active && is_enabled {
             return Ok(StageStatus::Skipped(
@@ -283,10 +297,14 @@ impl Mihoro {
         }
 
         if !is_enabled {
-            Systemctl::new().enable("mihomo.service").execute()?;
+            Systemctl::with_scope(self.systemd_scope)
+                .enable("mihomo.service")
+                .execute()?;
         }
         if !is_active {
-            Systemctl::new().start("mihomo.service").execute()?;
+            Systemctl::with_scope(self.systemd_scope)
+                .start("mihomo.service")
+                .execute()?;
         }
         Ok(StageStatus::Installed)
     }
@@ -370,7 +388,9 @@ impl Mihoro {
             "{} Stopping mihomo.service before overwriting...",
             DETAIL_PREFIX.yellow()
         );
-        Systemctl::new().stop("mihomo.service").execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .stop("mihomo.service")
+            .execute()?;
 
         // Extract and overwrite the binary
         extract_gzip(
@@ -465,7 +485,9 @@ impl Mihoro {
 
     pub async fn restart_service(&self) -> Result<StageStatus> {
         println!("{} Restarting mihomo.service...", DETAIL_PREFIX.cyan());
-        Systemctl::new().restart("mihomo.service").execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .restart("mihomo.service")
+            .execute()?;
         Ok(StageStatus::Installed)
     }
 
@@ -481,7 +503,7 @@ impl Mihoro {
         )?;
 
         // Restart mihomo systemd service
-        Systemctl::new()
+        Systemctl::with_scope(self.systemd_scope)
             .restart("mihomo.service")
             .execute()
             .map(|_| {
@@ -491,14 +513,22 @@ impl Mihoro {
     }
 
     pub fn uninstall(&self) -> Result<()> {
-        Systemctl::new().stop("mihomo.service").execute()?;
-        Systemctl::new().disable("mihomo.service").execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .stop("mihomo.service")
+            .execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .disable("mihomo.service")
+            .execute()?;
 
         delete_file(&self.mihomo_target_service_path, self.prefix.cyan())?;
         delete_file(&self.mihomo_target_config_path, self.prefix.cyan())?;
 
-        Systemctl::new().daemon_reload().execute()?;
-        Systemctl::new().reset_failed().execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .daemon_reload()
+            .execute()?;
+        Systemctl::with_scope(self.systemd_scope)
+            .reset_failed()
+            .execute()?;
         println!(
             "{} Disabled and reloaded systemd services",
             self.prefix.green()
@@ -635,7 +665,11 @@ fn normalize_mihomo_version_token(token: &str) -> Option<String> {
 /// Render the systemd unit file content for mihomo.service.
 ///
 /// Reference: https://wiki.metacubex.one/startup/service/
-fn render_service_string(binary_path: &str, config_root: &str) -> String {
+fn render_service_string(binary_path: &str, config_root: &str, scope: SystemdScope) -> String {
+    let wanted_by = match scope {
+        SystemdScope::User => "default.target",
+        SystemdScope::System => "multi-user.target",
+    };
     format!(
         "[Unit]
 Description=mihomo Daemon, Another Clash Kernel.
@@ -651,8 +685,8 @@ ExecStart={} -d {}
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
-WantedBy=default.target",
-        binary_path, config_root
+WantedBy={}",
+        binary_path, config_root, wanted_by
     )
 }
 

--- a/src/systemctl.rs
+++ b/src/systemctl.rs
@@ -2,54 +2,76 @@ use std::process::{Command, ExitStatus};
 
 use anyhow::{Context, Result};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SystemdScope {
+    User,
+    System,
+}
+
 pub struct Systemctl {
     systemctl: Command,
+    scope: SystemdScope,
 }
 
 impl Systemctl {
-    pub fn new() -> Self {
+    pub fn with_scope(scope: SystemdScope) -> Self {
         Self {
             systemctl: Command::new("systemctl"),
+            scope,
+        }
+    }
+
+    fn add_scope_arg(&mut self) {
+        if matches!(self.scope, SystemdScope::User) {
+            self.systemctl.arg("--user");
         }
     }
 
     pub fn enable(&mut self, service: &str) -> &mut Self {
-        self.systemctl.arg("--user").arg("enable").arg(service);
+        self.add_scope_arg();
+        self.systemctl.arg("enable").arg(service);
         self
     }
 
     pub fn start(&mut self, service: &str) -> &mut Self {
-        self.systemctl.arg("--user").arg("start").arg(service);
+        self.add_scope_arg();
+        self.systemctl.arg("start").arg(service);
         self
     }
 
     pub fn stop(&mut self, service: &str) -> &mut Self {
-        self.systemctl.arg("--user").arg("stop").arg(service);
+        self.add_scope_arg();
+        self.systemctl.arg("stop").arg(service);
         self
     }
 
     pub fn restart(&mut self, service: &str) -> &mut Self {
-        self.systemctl.arg("--user").arg("restart").arg(service);
+        self.add_scope_arg();
+        self.systemctl.arg("restart").arg(service);
         self
     }
 
     pub fn status(&mut self, service: &str) -> &mut Self {
-        self.systemctl.arg("--user").arg("status").arg(service);
+        self.add_scope_arg();
+        self.systemctl.arg("status").arg(service);
         self
     }
 
     pub fn disable(&mut self, service: &str) -> &mut Self {
-        self.systemctl.arg("--user").arg("disable").arg(service);
+        self.add_scope_arg();
+        self.systemctl.arg("disable").arg(service);
         self
     }
 
     pub fn daemon_reload(&mut self) -> &mut Self {
-        self.systemctl.arg("--user").arg("daemon-reload");
+        self.add_scope_arg();
+        self.systemctl.arg("daemon-reload");
         self
     }
 
     pub fn reset_failed(&mut self) -> &mut Self {
-        self.systemctl.arg("--user").arg("reset-failed");
+        self.add_scope_arg();
+        self.systemctl.arg("reset-failed");
         self
     }
 
@@ -60,11 +82,13 @@ impl Systemctl {
             .with_context(|| "failed to execute systemctl")
     }
 
-    /// Returns `true` if the given user service is currently active.
-    pub fn is_active(service: &str) -> bool {
-        Command::new("systemctl")
-            .arg("--user")
-            .arg("is-active")
+    /// Returns `true` if the given service is currently active.
+    pub fn is_active(&self, service: &str) -> bool {
+        let mut cmd = Command::new("systemctl");
+        if matches!(self.scope, SystemdScope::User) {
+            cmd.arg("--user");
+        }
+        cmd.arg("is-active")
             .arg("--quiet")
             .arg(service)
             .status()
@@ -72,11 +96,13 @@ impl Systemctl {
             .unwrap_or(false)
     }
 
-    /// Returns `true` if the given user service is enabled for autostart.
-    pub fn is_enabled(service: &str) -> bool {
-        Command::new("systemctl")
-            .arg("--user")
-            .arg("is-enabled")
+    /// Returns `true` if the given service is enabled for autostart.
+    pub fn is_enabled(&self, service: &str) -> bool {
+        let mut cmd = Command::new("systemctl");
+        if matches!(self.scope, SystemdScope::User) {
+            cmd.arg("--user");
+        }
+        cmd.arg("is-enabled")
             .arg("--quiet")
             .arg(service)
             .status()


### PR DESCRIPTION
### Description

This PR adds support for installing and managing services at the system level.

Currently, service operations are mainly handled in the default user-level scope. This change introduces a --system CLI option and updates the related service management logic so commands can be executed against either user-level or system-level systemd services.

### Linked Issues

Related to #199

### Additional context

This allows Mihoro to keep running after user logout when installed as a system-level service.
